### PR TITLE
Fix error in read_prn if no empty col, remove pandas inplace for >=2.0 compatibility

### DIFF
--- a/pymarthe/helpers/postprocessing.py
+++ b/pymarthe/helpers/postprocessing.py
@@ -630,7 +630,9 @@ class PestPostProcessing():
                 par_df = pd.read_csv(self.pst.filename.replace('.pst', '.par.{}'.format(str(it + 1))),
                                      skiprows = [0], usecols = [1],
                                      header = None, sep = r'\s+', index_col = False)
-                par_df.set_index(self.pst.parameter_data.parnme, inplace = True)
+                # am : inplace not allowed anymore in pandas>=2.0
+                # par_df.set_index(self.pst.parameter_data.parnme, inplace = True)
+                par_df = par_df.set_index(self.pst.parameter_data.parnme)
                 par_df.columns = ['it' + str(it + 1)]
                 ipar_list.append(par_df.T)
                 # ---- Concat all values

--- a/pymarthe/helpers/preprocessing.py
+++ b/pymarthe/helpers/preprocessing.py
@@ -88,7 +88,9 @@ def spatial_aggregation(mm, x, y, layer, value, agg = 'sum', trans ='none', only
         agg_df = agg_df.loc[[mm.all_active(n) for n in agg_df.node]]
 
     # -- Rename value column for merging purpose
-    agg_df.rename({'_value': 'value'}, axis = 1, inplace=True)
+    # am 2023-11-24, inplace not allowed anymore in pandas
+    # agg_df.rename({'_value': 'value'}, axis = 1, inplace=True)
+    agg_df = agg_df.rename({'_value': 'value'}, axis = 1)
 
     # -- Merge aggregated/initial DataFrames 
     res = pd.merge(df, agg_df).drop_duplicates('node').drop('_value',axis=1)
@@ -340,7 +342,9 @@ def extract_Hubeau_head_records(code_bss, start_date, end_date):
 
     # ---- Set DateTimeIndex
     df['date'] = pd.to_datetime(df['date_mesure'])
-    df.set_index('date', inplace=True)
+    # am 2023-11-24, inplace not allowed anymore in pandas
+    # df.set_index('date', inplace=True)
+    df = df.set_index('date')
 
     # ---- Return DataFrame
     return df

--- a/pymarthe/mfield.py
+++ b/pymarthe/mfield.py
@@ -1453,7 +1453,9 @@ class MartheFieldSeries():
             # -- Manage masked vales
             df  = df[~df['value'].isin(mv)]
             # -- Change column name according to istep
-            df.rename(columns={'value': mf.field}, inplace=True)
+            # am 2023-11-inplace not authorized anymore in pandas
+            # df.rename(columns={'value': mf.field}, inplace=True)
+            df = df.rename(columns={'value': mf.field})
             dfs.append(df)
 
         # -- Concatenate drop duplicated layer,inest,i,j,x,y columns

--- a/pymarthe/moptim.py
+++ b/pymarthe/moptim.py
@@ -1437,7 +1437,9 @@ class MartheOptim():
                     axis=1)
             )
         param_df['parnme'] = param_df['parnme'].str.replace('__','_')
-        param_df.set_index('parnme', drop = False, inplace = True)
+        # am: inplace not allowed since pandas >= 2.0
+        # param_df.set_index('parnme', drop = False, inplace = True)
+        param_df = param_df.set_index('parnme', drop = False)
 
         # -- Disable parameter transformation (already done by pyMarthe)
         param_df['partrans'] = 'none'

--- a/pymarthe/mpump.py
+++ b/pymarthe/mpump.py
@@ -400,8 +400,11 @@ class MarthePump():
         mp.switch_boundnames(switch_dic = {'B1951752/F1': 'F1'})
         """
         # ---- Use .replace method on boundname column
-        self._data['boundname'].replace(switch_dic, inplace=True)
-        self.data['boundname'].replace(switch_dic, inplace=True)
+        # am 2023-11-24: inplace not authorized in newer versions of pandas
+        # self._data['boundname'].replace(switch_dic, inplace=True)
+        self._data['boundname'] = self._data['boundname'].replace(switch_dic)
+        # self.data['boundname'].replace(switch_dic, inplace=True)
+        self.data['boundname'] = self.data['boundname'].replace(switch_dic)
 
 
 

--- a/pymarthe/utils/marthe_utils.py
+++ b/pymarthe/utils/marthe_utils.py
@@ -900,7 +900,9 @@ def read_prn(prnfile = 'historiq.prn'):
         df = pd.read_csv(prnfile, sep='\t', encoding=encoding, 
                          skiprows=mask.count(True) + add_skip, index_col = 0,
                          )
-    df.dropna(axis=1, how = 'all', inplace = True)  # drop empty columns if exists
+    # am 2023-11-24: in recent version of pandas, inplace is not authorized anymore
+    # df.dropna(axis=1, how = 'all', inplace = True)  # drop empty columns if exists
+    df = df.dropna(axis=1, how = 'all')  # drop empty columns if exists
     # ---- Format DateTimeIndex or float
     df.index.name = 'date'
     # ---- Set columns as multi-index as columns
@@ -969,7 +971,9 @@ def read_histo_file(histo_file):
     # ---- Build histo DataFrame
     cols = ['type','inest','loc_type','x','y','layer','id', 'label']
     df = pd.DataFrame(data, columns = cols)
-    df.set_index('id', inplace = True)
+    # am: remove inplace for pandas (>=2.0)
+    # df.set_index('id', inplace = True)
+    df = df.set_index('id')
     # ---- Return histo DataFrame
     return df
 

--- a/pymarthe/utils/marthe_utils.py
+++ b/pymarthe/utils/marthe_utils.py
@@ -900,14 +900,15 @@ def read_prn(prnfile = 'historiq.prn'):
         df = pd.read_csv(prnfile, sep='\t', encoding=encoding, 
                          skiprows=mask.count(True) + add_skip, index_col = 0,
                          )
-    # am 2023-11-24: in recent version of pandas, inplace is not authorized anymore
-    # df.dropna(axis=1, how = 'all', inplace = True)  # drop empty columns if exists
-    df = df.dropna(axis=1, how = 'all')  # drop empty columns if exists
     # ---- Format DateTimeIndex or float
     df.index.name = 'date'
     # ---- Set columns as multi-index as columns
     midx = pd.MultiIndex.from_tuples(tuples, names=idx_names)
     df.columns = midx
+    # am 2023-11-24: in recent version of pandas, inplace is not authorized anymore
+    # and move after multiindex to avoid error on len(tupes) vs. len(df.columns)
+    # df.dropna(axis=1, how = 'all', inplace = True)  # drop empty columns if exists
+    df = df.dropna(axis=1, how = 'all')  # drop empty columns if exists
     # ---- Trandform inest id to integer
     if nest:
         levels = df.columns.get_level_values('inest').astype(int).unique()

--- a/pymarthe/utils/marthe_utils.py
+++ b/pymarthe/utils/marthe_utils.py
@@ -851,7 +851,12 @@ def read_prn(prnfile = 'historiq.prn'):
     add_skip = 1
     with open(prnfile, 'r', encoding=encoding) as f:
         # ----Fetch 5 first lines of prn file 
-        flines_arr = np.array([f.readline().split('\t')[:-1] for i in range(5)], dtype=list)
+        
+        # am 2023-11-24 : in some version of marthe, no empty col at the end of file.
+        # using [:-1] would drop a real column and raise error while renaming columns in line 904
+        # flines_arr = np.array([f.readline().split('\t')[:-1] for i in range(5)], dtype=list)
+        flines_arr = np.array([f.readline().split('\t') for i in range(5)], dtype=list)
+
         # ---- Create a boolean mask to read only usefull header lines
         mask = [False, True, False, True , False]
         # ---- Select only usefull first lines by mask
@@ -885,7 +890,9 @@ def read_prn(prnfile = 'historiq.prn'):
         df = pd.read_csv(prnfile, sep='\t', encoding=encoding, 
                          skiprows=mask.count(True) + add_skip, index_col = 0,
                          parse_dates = True, dayfirst=True)
-        df.drop(df.columns[0], axis=1,inplace=True)
+        # am 2023-11-24: in recent version of pandas, inplace is not authorized anymore
+        # df.drop(df.columns[0], axis=1,inplace=True)
+        df = df.drop(df.columns[0], axis=1)
     else :
         # ---- Get all headers as tuple
         tuples = [tuple(map(str.strip,list(t)) ) for t in list(zip(*headers))][1:]
@@ -902,7 +909,9 @@ def read_prn(prnfile = 'historiq.prn'):
     # ---- Trandform inest id to integer
     if nest:
         levels = df.columns.get_level_values('inest').astype(int).unique()
-        df.columns.set_levels(levels = levels, level='inest', inplace=True)
+        # am 2023-11-24: in recent version of pandas, inplace is not authorized anymore
+        # df.columns.set_levels(levels = levels, level='inest', inplace=True)
+        df.columns = df.columns.set_levels(levels = levels, level='inest')
     # ---- Return prn DataFrame
     return df
 
@@ -1610,7 +1619,9 @@ def read_zonebudget(filename= 'histobil_debit.prn'):
         # -- Convert to DataFrame skiping the useless additional headers and NaN columns
         zb_df = pd.read_table(StringIO(zb_table), skiprows=[1]).dropna(axis=1)
         # -- Drop numeric date column
-        zb_df.drop(columns=zb_df.columns[1], inplace=True)
+        # am 2023-11-24; inplace not authorized anymore in pandas
+        # zb_df.drop(columns=zb_df.columns[1], inplace=True)
+        zb_df = zb_df.drop(columns=zb_df.columns[1])
         # -- Manage column names
         zb_df.columns = ['date'] + list(zb_df.columns[1:].str.strip())
         # -- Convert date column to datetime format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,64 @@
+# --------- Pymarthe setup file ---------
+# allow `pip3 install -e .` for developper (edition) mode
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pymarthe"
+authors =[
+    {"name" = "Ryma Aissat"},
+    {"name" = "Alexandre Pryet"},
+    {"name" = "Pierre Matran"}
+]
+dynamic = ["version"]
+
+description = ""
+readme = {file = "README.md", content-type = "text/markdown"}   
+# license = {file = "LICENSE"}
+
+classifiers = [
+    "Programming Language :: Python : 3",
+    #"License :: MIT License",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Hydrology",
+]
+
+keywords = ["hydrology", "groundwater", "modelling", "uncertainty", "coupling", "pest", "pestpp"]
+
+requires-python = ">=3.7"
+dependencies = [
+    "pandas >= 1.3.5",
+    "numpy >= 1.18.5",
+    "appdirs >= 1.4.4",
+    "pathlib2 >= 2.3.5",
+    "Rtree >= 0.9.4",
+    "matplotlib >= 3.2.2",
+    "pyshp >= 2.1.2",
+    "pyemu >= 1.2.0",
+    "flopy"
+]
+
+[project.optional-dependencies]
+# install with `pip install pymarthe[extras]`
+extras = [
+    "pyvista >= 0.33.3",
+    "vtk >= 9.1.0",
+    "imageio >= 2.9.0"
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "pymarthe.__version__"}
+# authors = {attr = "pymarthe.__author__"} # not allow with pyproject.toml setup // allowed in cfg fmt
+
+[project.urls]
+Repository = "https://github.com/apryet/adeqwat"
+#Documentation = 
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+exclude = ["examples*", "assets*", "presentation*"]  # exclude packages matching these glob patterns (empty by default)
+


### PR DESCRIPTION
In `marthe_utils.read_prn()` the last column used to be drop (generally empty). This behaviour can cause mistakes (a true column is dropped if no empty column at the end of the `historiq.prn` file),or even error (different length in headers and data). A fix is proposed by reading all columns and just dropping the empty ones at the end.

Also, with pandas >= 2.0 `inplace=True` statement are not allowed anymore. Those statements have been rewritten in all pymarthe sources.