### PR TITLE
0-based layer in read_histo_file

### DIFF
--- a/pymarthe/utils/marthe_utils.py
+++ b/pymarthe/utils/marthe_utils.py
@@ -960,6 +960,9 @@ def read_histo_file(histo_file):
     # ---- Build histo DataFrame
     cols = ['type','inest','loc_type','x','y','layer','id', 'label']
     df = pd.DataFrame(data, columns = cols)
+    # convert layer to 0_based
+    df['layer'] = df.layer - 1 
+    print('INFO : layer id in read_histo_file df is 0-based.')
     df.set_index('id', inplace = True)
     # ---- Return histo DataFrame
     return df


### PR DESCRIPTION
Hello,
I know this is sometimes cumbersome, but my opinion is that we have to stick with a principle: all indices (such as row, col or layer) should be 0-based within PyMarthe, and 1-based out of it (once written to file). 

This has no impact within PyMarthe; but users may be confused, I  temporarily added a print("INFO ...") 