### PR TITLE
Several bug fix and upgrades

### DIFF
--- a/pymarthe/__init__.py
+++ b/pymarthe/__init__.py
@@ -35,6 +35,7 @@ print(
 # ---- Imports from main library
 from .marthe import MartheModel
 from .mfield import MartheField
+from .mfield import MartheFieldSeries
 from .moptim import MartheOptim
 from .msoil import MartheSoil
 from .mpump import MarthePump

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -128,6 +128,7 @@ class MartheModel():
         # ---- Manage spatial index instance
         # From existing external file
         if isinstance(spatial_index, str):
+            spatial_index = self._check_si_input(spatial_index)
             self.si_state = 1       # activate spatial index
             from rtree.index import Index
             self.spatial_index = Index(spatial_index)
@@ -1653,6 +1654,42 @@ class MartheModel():
                                           external= external,
                                           new_pastpfile= new_pastpfile)
 
+    def _check_si_input(self, spatial_index: str) -> str:
+        """
+        Removes '.dat' or '.idx' if provde by the user.
+        Intent to capture a FileNotFoundError if index files are not found.
+
+        Parameters
+        ----------
+        spatial_index : str
+            The relative or absolute path to the spatial index prefix file.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the corresponding '.dat' or '.idx' files do not exist.
+        Returns
+        ------
+            spatial_index : path to the spatial index file fixed.
+        """
+
+        # Fix spatial_index argument if it's not valid (remove extention)
+        if spatial_index.endswith(('.dat', '.idx')):
+            spatial_index_fix = spatial_index[:-4]
+        else:
+            spatial_index_fix = spatial_index
+
+        # Checks if spatial_index files exist
+        spatial_index_dat = spatial_index_fix + ".dat"
+        spatial_index_idx = spatial_index_fix + ".idx"
+        if (not os.path.exists(spatial_index_dat) or not
+                os.path.exists(spatial_index_idx)):
+            raise FileNotFoundError(
+                f"Path or file '{os.path.join(os.getcwd(), spatial_index_idx)}' or "
+                f"'{os.path.join(os.getcwd(), spatial_index_dat)}' do not exists."
+            )
+
+        return spatial_index_fix
 
     def __str__(self):
         """

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -152,9 +152,6 @@ class MartheModel():
         else:
             self.modelgrid = None
 
-
-
-
     def __iter__(self, only_active=False):
 
         """
@@ -241,7 +238,6 @@ class MartheModel():
                     # -- Incrementation of unique cell id
                     node += 1
 
-
     def build_spatial_index(self, name=None, only_active=False):
         """
         Function to build a spatial index on field data.
@@ -283,9 +279,6 @@ class MartheModel():
         si.flush()
         self.sifile = si_name
         self.spatial_index = si
-
-
-
 
     def build_modelgrid(self, add_z=False):
         """
@@ -352,7 +345,6 @@ class MartheModel():
 
         # -- Set DataFrame to .modelgrid attribute
         self.modelgrid = df
-
 
     def _get_top_bottom_arrays(self):
         """
@@ -426,8 +418,6 @@ class MartheModel():
         # -- Return top and botm arrays
         return _top, _hsubs
 
-
-
     def load_geometry(self, g=None, **kwargs):
         """
         Load and store geometry grid information of a MartheModel instance.
@@ -468,8 +458,6 @@ class MartheModel():
                                           use_imask=kwargs.get('use_imask', False)
                                           )
 
-
-
     def build_imask(self):
         """
         Function to build a imask field based on permh
@@ -495,8 +483,6 @@ class MartheModel():
         imask.data['value'] = (imask.data['value'] != 0).astype(int)
         # ---- Return MartheField instance
         return imask
-
-
 
     def load_prop(self, prop, **kwargs):
         """
@@ -550,9 +536,6 @@ class MartheModel():
         else:
             print(f"Property `{prop}` not supported.")
 
-
-
-
     def write_prop(self, prop=None):
         """
         Write MartheModel required properties by name.
@@ -591,9 +574,6 @@ class MartheModel():
         # -- Write required properties
         for p in props:
             self.prop[p].write_data()
-
-
-
 
     @classmethod
     def from_config(cls, configfile):
@@ -653,7 +633,6 @@ class MartheModel():
         # -- Return MartheModel instance
         return mm
 
-
     def get_extent(self):
         """
         Return the model domain extension.
@@ -679,8 +658,6 @@ class MartheModel():
             extent = self.spatial_index.bounds
         # -- Return
         return extent
-
-
 
     def get_edges(self, closed=False):
         """
@@ -719,10 +696,6 @@ class MartheModel():
         # -- Return
         return edges
 
-
-
-
-
     def remove_autocal(self):
         """
         Function to make marthe auto calibration silent.
@@ -743,16 +716,14 @@ class MartheModel():
         """
         marthe_utils.remove_autocal(self.rma_file, self.mlfiles['mart'])    
 
-
-
-    def make_silent(self):
+    def set_verbosity(self, silent: bool) -> None:
         """
-        Function to make marthe run silent
+        Function to run marthe model either silently or with verbose output
 
         Parameters:
         ----------
         self : MartheModel instance
-
+        silent : bool
         Returns:
         --------
         Write in .mart inplace
@@ -760,11 +731,9 @@ class MartheModel():
         Examples:
         --------
         mm = MartheModel(rma_file)
-        mm.make_silent()
+        mm.set_verbosity(silent=True)
         """
-        marthe_utils.make_silent(self.mlfiles['mart']) 
-
-
+        marthe_utils.set_verbosity(self.mlfiles['mart'], silent)
 
     def get_outcrop(self, as_2darray=False, base=0):
         """
@@ -1360,9 +1329,8 @@ class MartheModel():
         buff = []
         normal_msg='normal termination'
 
-        # ---- Force model to run as silent if required
-        if silent:
-            self.make_silent()
+        # ---- Set the verbosity of the model
+        self.set_verbosity(silent)
 
         # ---- Check to make sure that program and namefile exist
         exe = which(exe_name)

--- a/pymarthe/mfield.py
+++ b/pymarthe/mfield.py
@@ -254,10 +254,6 @@ class MartheField():
         else:
             return self.data[mask]
 
-
-
-
-
     def set_data(self, data, layer=None, inest=None):
         """
         Set field data for active cells (where imask is 1) and NON-masked values (see dmv)
@@ -288,6 +284,11 @@ class MartheField():
         mf.set_data(2.3e-3, layer=2, inest=3) # one nest
 
         """
+        # ---- Checks if layer in mm.nlay
+        if layer is not None and layer not in range(self.mm.nlay):
+            raise ValueError(f"layer {layer} does not exist, "
+                             f"choose one from layer 0 to layer {self.mm.nlay-1}")
+
         # ---- Set all useful conditions
         _none = all(x is None for x in [layer, inest])
         _str = isinstance(data, str)
@@ -327,14 +328,18 @@ class MartheField():
         if _rec:
             self.data = self.get_masked(data)
 
-        # ---- Manage 3D-array input
-        if np.logical_and.reduce([_arr, not _rec, _none]):
-            # -- Verify data is a 3D-array
-            err_msg = f"ERROR: `data` array must be 3D. Given shape: {data.shape}."
-            assert len(data.shape) == 3, err_msg
-            self.data = self.get_masked(self._3d2rec(data))
+        # ---- Manage 2D-3D-array input
+        if _arr:
 
+            err_msg = (f"ERROR: `data` array must be 2D with a layer argmuent or"
+                       f"3D with layer=None. Given shape: {len(data.shape)}, given layer = {layer}.")
 
+            if len(data.shape) == 3 and layer is None:
+                self.data = self.get_masked(self._3d2rec(data))
+            elif len(data.shape) == 2 and layer is not None:
+                self.data = self.get_masked(self._2d2rec(data,layer))
+            else:
+                raise ValueError(err_msg)
 
     def get_masked(self, rec):
         """
@@ -478,13 +483,11 @@ class MartheField():
         # ---- Stack all recarrays as once
         return rec
 
-
-
     def _3d2rec(self, arr3d):
         """
         Convert 3D-array
         Wrapper of marthe_utils.read_grid_file().
-
+        Note sma : docstring looks deprecated, it should be rewrite
         Parameters:
         ----------
         filename (str) : path to Marthe field property file.
@@ -498,22 +501,21 @@ class MartheField():
         Examples:
         --------
         rec = mf._grid2rec('mymodel.emmca')
-        
+
         """
+        # TODO : may be remove ? Actualy this check is late,
+        # TODO : we may check the mm instance in the MartheField class __init__()
+        # TODO : Will be fixed with a minor commit
         # ---- Assert MartheModel exist
         err_msg = "ERROR: Building a `MartheField` instance from a 3D-array " \
                   "require a referenced `MartheModel` instance. " \
                   "Try MartheField(field, data, mm = MartheModel('mymodel.rma'))."
-        assert self.mm.__str__() == 'MartheModel' , err_msg
-
-        # ---- Assert array is 3D
-        err_msg = f"ERROR: `data` must be a 3D-array. Given shape: {arr3d.shape}"
-        assert len(arr3d.shape) == 3, err_msg
+        assert self.mm.__str__() == 'MartheModel', err_msg
 
         # ---- Fetch basic model structure
         rec = deepcopy(self.mm.imask.data)
         df = pd.DataFrame.from_records(rec)
-        
+
         # ---- Modify rec inplace
         for layer, arr2d in enumerate(arr3d):
             mask = (df.layer == layer) & (df.inest == 0)
@@ -522,8 +524,36 @@ class MartheField():
         # ---- Return recarray
         return df.to_records(index=False)
 
+    def _2d2rec(self, arr, layer=None):
+        """
+        Convert 2D-array to rec array. This method is called by the
+        MartheField.set_data method and should not be called directly.
 
+        Parameters:
+        ----------
+        arr (np.ndarray) : A 2D numpy ndarray.
 
+        Returns:
+        --------
+        rec (np.recarray) : recarray with all usefull informations
+                            for each model grid cell such as layer,
+                            inest, value, ...
+        """
+        # ---- Assert MartheModel exist
+        err_msg = "ERROR: Building a `MartheField` instance from a 3D-array " \
+                  "require a referenced `MartheModel` instance. " \
+                  "Try MartheField(field, data, mm = MartheModel('mymodel.rma'))."
+        assert self.mm.__str__() == 'MartheModel', err_msg
+
+        # ---- Fetch basic model structure
+        rec = deepcopy(self.mm.imask.data)
+        df = pd.DataFrame.from_records(rec)
+
+        mask = (df.layer == layer) & (df.inest == 0)
+        df.loc[mask, 'value'] = arr.ravel()
+
+        # ---- Return recarray
+        return df.to_records(index=False)
 
     def _rec2grid(self, layer, inest):
         """

--- a/pymarthe/mfield.py
+++ b/pymarthe/mfield.py
@@ -61,8 +61,14 @@ class MartheField():
         -----------
         mm.mobs.compute_weights(lambda_dic)
         """
-        self.field = field
+        # ----Check for mm type, avoid futures checks and uncaptured errors
+        from .marthe import MartheModel
+        if not isinstance(mm, MartheModel):
+            raise TypeError(f"mm must be a MartheModel, not a {type(mm).__name__}")
+
+        # ---- Set attributes
         self.mm = mm
+        self.field = field
         self.dmv = dmv
         self.use_imask = use_imask
         self.set_data(data)
@@ -337,7 +343,7 @@ class MartheField():
             if len(data.shape) == 3 and layer is None:
                 self.data = self.get_masked(self._3d2rec(data))
             elif len(data.shape) == 2 and layer is not None:
-                self.data = self.get_masked(self._2d2rec(data,layer))
+                self.data = self.get_masked(self._2d2rec(data, layer))
             else:
                 raise ValueError(err_msg)
 
@@ -503,15 +509,6 @@ class MartheField():
         rec = mf._grid2rec('mymodel.emmca')
 
         """
-        # TODO : may be remove ? Actualy this check is late,
-        # TODO : we may check the mm instance in the MartheField class __init__()
-        # TODO : Will be fixed with a minor commit
-        # ---- Assert MartheModel exist
-        err_msg = "ERROR: Building a `MartheField` instance from a 3D-array " \
-                  "require a referenced `MartheModel` instance. " \
-                  "Try MartheField(field, data, mm = MartheModel('mymodel.rma'))."
-        assert self.mm.__str__() == 'MartheModel', err_msg
-
         # ---- Fetch basic model structure
         rec = deepcopy(self.mm.imask.data)
         df = pd.DataFrame.from_records(rec)
@@ -539,16 +536,9 @@ class MartheField():
                             for each model grid cell such as layer,
                             inest, value, ...
         """
-        # ---- Assert MartheModel exist
-        err_msg = "ERROR: Building a `MartheField` instance from a 3D-array " \
-                  "require a referenced `MartheModel` instance. " \
-                  "Try MartheField(field, data, mm = MartheModel('mymodel.rma'))."
-        assert self.mm.__str__() == 'MartheModel', err_msg
-
         # ---- Fetch basic model structure
         rec = deepcopy(self.mm.imask.data)
         df = pd.DataFrame.from_records(rec)
-
         mask = (df.layer == layer) & (df.inest == 0)
         df.loc[mask, 'value'] = arr.ravel()
 

--- a/pymarthe/mpump.py
+++ b/pymarthe/mpump.py
@@ -225,11 +225,11 @@ class MarthePump():
 
         # ---- Build query (format: q = 'column_0 in [value_0,..] & ...'')
         q = ' & '.join(
-            ["{} in {}".format(k, list(self.data[k].unique()))
-             if v is None else "{} in {}".format(k, list(marthe_utils.make_iterable(v)))
-             for k, v
-             in zip(col_query, [istep, node, layer, i, j, boundname])
-             ]
+            [
+                "{} in {}".format(k, self.data[k].unique().tolist()) if v is None
+                else "{} in {}".format(k, list(marthe_utils.make_iterable(v)))
+                for k, v in zip(col_query, [istep, node, layer, i, j, boundname])
+            ]
         )
 
         # ---- Force all provided isteps (slow)

--- a/pymarthe/mpump.py
+++ b/pymarthe/mpump.py
@@ -12,13 +12,14 @@ import warnings
 
 encoding = 'latin-1'
 
+
 class MarthePump():
     """
     Class for handling Marthe pumping data.
 
     """
 
-    def __init__(self, mm, pastp_file = None,  mode = 'aquifer', verbose=False):
+    def __init__(self, mm, pastp_file=None, mode='aquifer', verbose=False):
         """
         MarthePump class : available for aquifer or river pumping.
 
@@ -60,10 +61,6 @@ class MarthePump():
         if verbose:
             self._verbose()
 
-
-
-
-
     def _verbose(self):
         """
         Perform some classic checks about pumping data validity and print
@@ -78,37 +75,32 @@ class MarthePump():
             for node in self.data['node']:
                 if self.mm.imask.data['value'][node] == 0:
                     coords = 'Node = {}, Layer = {}, Nested = {}, Row = {}, Column = {} .'.format(
-                                    node,
-                                    self.mm.imask.data['layer'][node],
-                                    self.mm.imask.data['inest'][node],
-                                    self.mm.imask.data['i'][node],
-                                    self.mm.imask.data['j'][node]
-                                )
+                        node,
+                        self.mm.imask.data['layer'][node],
+                        self.mm.imask.data['inest'][node],
+                        self.mm.imask.data['i'][node],
+                        self.mm.imask.data['j'][node]
+                    )
                     warnings.warn(warn_msg + coords)
         except:
             pass
 
-
-
         # -- Search for several pumping data on same node
         warn_msg = "Multiple pumping condition in same cell : "
         try:
-            agg = self.data.groupby(['istep','node'], as_index=False).size()
+            agg = self.data.groupby(['istep', 'node'], as_index=False).size()
             nodes = agg.loc[agg['size'] > 1, 'node'].unique()
             for node in nodes:
                 coords = 'Node = {}, Layer = {}, Nested = {}, Row = {}, Column = {} .'.format(
-                                node,
-                                self.mm.imask.data['layer'][node],
-                                self.mm.imask.data['inest'][node],
-                                self.mm.imask.data['i'][node],
-                                self.mm.imask.data['j'][node]
-                            )
+                    node,
+                    self.mm.imask.data['layer'][node],
+                    self.mm.imask.data['inest'][node],
+                    self.mm.imask.data['i'][node],
+                    self.mm.imask.data['j'][node]
+                )
                 warnings.warn(warn_msg + coords)
         except:
             pass
-
-
-
 
     def _extract_data(self, mode):
         """
@@ -129,7 +121,7 @@ class MarthePump():
         mp._extract_data()
 
         """
-        
+
         # ---- Manage 'aqpump'
         if self.mode == 'aquifer':
             d, _d = marthe_utils.extract_pastp_pumping(self.pastp_file, mode)
@@ -137,20 +129,36 @@ class MarthePump():
         # ---- Manage 'rivpump'
         elif self.mode == 'river':
             # ---- Convert aff/trc data in column, line, plan (layer) format in .pastp file
-            marthe_utils.convert_at2clp(self.pastp_file, mm = self.mm)
+            marthe_utils.convert_at2clp(self.pastp_file, mm=self.mm)
             d, _d = marthe_utils.extract_pastp_pumping(self.pastp_file, mode)
 
         # -- Manage xy inputs
-        if all(loc in d.columns for loc in list('xy')):
-            # -- Print message to inform about convertion
+        if all(loc in d.columns for loc in ['x', 'y']):
             print('Converting xy pumping data into row(s), column(s) ...')
-            # -- Get all nodes
-            nodes = self.mm.get_node(x=_d.x,y=_d.y,layer=_d.layer)
-            # -- Perform query on modlegrid
-            _d[['node','i','j']] = self.mm.query_grid(node=nodes, target=['i','j']).reset_index()
-            # -- Push to class attribute
-            self.data, self._data = _d[self.vars], _d[self._vars + ['x','y']]
+            # -- In case that col x and y have nan values
+            if _d['x'].isna().any() or _d['y'].isna().any():
+                # -- Keep only rows with valid x and y
+                _d_clean = _d.dropna(subset=['x', 'y'])
 
+                # -- Get nodes and query model grid
+                nodes = self.mm.get_node(x=_d_clean['x'], y=_d_clean['y'], layer=_d_clean['layer'])
+                grid_info = self.mm.query_grid(node=nodes, target=['i', 'j']).reset_index()
+
+                # -- Update _d_clean with grid info
+                _d_clean = _d_clean.reset_index(drop=False)
+                _d_clean[['node', 'i', 'j']] = grid_info
+                _d_clean.set_index('index', inplace=True)
+
+                # -- Update original DataFrame with computed data
+                _d.loc[_d_clean.index, ['node', 'i', 'j']] = _d_clean[['node', 'i', 'j']]
+            else:
+                # -- All rows are valid: process directly
+                nodes = self.mm.get_node(x=_d['x'], y=_d['y'], layer=_d['layer'])
+                _d[['node', 'i', 'j']] = self.mm.query_grid(node=nodes, target=['i', 'j']).reset_index()
+            # -- Push final data to class attributes
+            self.data = _d[self.vars]
+            self._data = _d[self._vars + ['x', 'y']]
+            print(self.data, self._data)
         # -- Manage ij inputs
         else:
             # -- Perform query on modelgrid
@@ -158,21 +166,16 @@ class MarthePump():
             # -- Push to class attribute
             self.data, self._data = _d[self.vars], _d[self._vars]
 
-
         # ---- Set generic boundnames
         digits = len(str(self.data.node.max()))
-        bdnmes =  ['{}_{}'.format(
-                        self.prop_name,
-                        str(node).zfill(digits)
-                        )
-                    for node in self.data.node]
-        self.data['boundname'], self._data['boundname'] = [bdnmes]*2
+        bdnmes = ['{}_{}'.format(
+            self.prop_name,
+            str(node).zfill(digits)
+        )
+            for node in self.data.node]
+        self.data['boundname'], self._data['boundname'] = [bdnmes] * 2
 
-
-
-
-
-    def get_data(self, istep=None, node=None, layer=None, i=None, j=None, boundname=None, force=False , as_mask=False):
+    def get_data(self, istep=None, node=None, layer=None, i=None, j=None, boundname=None, force=False, as_mask=False):
         """
         Function to select/subset pumping data.
 
@@ -222,13 +225,13 @@ class MarthePump():
 
         # ---- Build query (format: q = 'column_0 in [value_0,..] & ...'')
         q = ' & '.join(
-                ["{} in {}".format(k, list(self.data[k].unique())) 
-                    if v is None else "{} in {}".format(k, list(marthe_utils.make_iterable(v)))
-                    for k, v 
-                    in zip(col_query, [istep,node,layer,i,j,boundname])
-                    ]
-                        )
-        
+            ["{} in {}".format(k, list(self.data[k].unique()))
+             if v is None else "{} in {}".format(k, list(marthe_utils.make_iterable(v)))
+             for k, v
+             in zip(col_query, [istep, node, layer, i, j, boundname])
+             ]
+        )
+
         # ---- Force all provided isteps (slow)
         if force:
             # -- Subset (without timestep)
@@ -238,7 +241,7 @@ class MarthePump():
                 df = df_ss.loc[df_ss.istep == istep]
                 # -- If istep not provided in pastp file
                 if df.empty:
-                    nip = df_ss.loc[df_ss.istep < istep, 'istep'].max()   # nip = nearest previous istep
+                    nip = df_ss.loc[df_ss.istep < istep, 'istep'].max()  # nip = nearest previous istep
                     np_df = df_ss[df_ss.istep == nip]
                     np_df['istep'] = istep
                     dfs.append(np_df)
@@ -268,11 +271,6 @@ class MarthePump():
         else:
             return df
 
-
-
-
-
-
     def set_data_from_parfile(self, parfile, keys, value_col, btrans):
         """
         """
@@ -281,7 +279,7 @@ class MarthePump():
         # -- Get kmi and transformed values
         kmi, bvalues = pest_utils.parse_mlp_parfile(parfile, keys, value_col, btrans)
         # find intersection of keys with parameter data columns
-        for k in kmi.names :
+        for k in kmi.names:
             if k not in df.columns:
                 kmi = kmi.droplevel(k)
         # -- Convert to MultiIndex Dataframe
@@ -291,9 +289,6 @@ class MarthePump():
         data = mi_df.reset_index()
         # -- Set data inplace
         self.data, self._data = data[self.vars], data[self._vars]
-
-
-
 
     def set_data(self, value, istep=None, node=None, layer=None, i=None, j=None, boundname=None):
         """
@@ -340,9 +335,6 @@ class MarthePump():
         # ---- Replace previous data
         self._data, self.data = df[self._vars], df[self.vars]
 
-
-
-
     def get_boundnames(self, istep=None, layer=None, i=None, j=None):
         """
         Function to get boundname on subset data.
@@ -380,8 +372,6 @@ class MarthePump():
         # ---- Return boundnames as list of string
         return boundnames
 
-
-
     def switch_boundnames(self, switch_dic):
         """
         Function to change boundname of a pumping point by another.
@@ -405,9 +395,6 @@ class MarthePump():
         self._data['boundname'] = self._data['boundname'].replace(switch_dic)
         # self.data['boundname'].replace(switch_dic, inplace=True)
         self.data['boundname'] = self.data['boundname'].replace(switch_dic)
-
-
-
 
     def split_qtype(self, qtype=None):
         """
@@ -444,17 +431,13 @@ class MarthePump():
         gb = self._data.groupby('qtype')
 
         # ---- Split data by qtype
-        dfs = [gb.get_group(qt) 
+        dfs = [gb.get_group(qt)
                if qt in self._data['qtype'].unique()
-               else pd.DataFrame() 
+               else pd.DataFrame()
                for qt in qtypes]
 
         # ---- Return list of (required) DataFrames
         return dfs
-
-
-
-
 
     def _write_mail(self):
         """
@@ -504,11 +487,11 @@ class MarthePump():
                 df = mail_df.loc[mail_df['istep'] == istep]
                 # ---- Update replace dictionary for this istep
                 repl_dic = {}
-                for i,row in df.iterrows():
-                    c,l,p,v = row[['j','i','layer','value']].astype(str)
-                    match = r''.join(['C=', sp, c, 'L=', sp, l, 
-                                     'P=', sp, p, 'V=', sp, re_num])
-                    repl = 'C={:>7}L={:>7}P={:>7}V={:>10}'.format(c,l,p,v)
+                for i, row in df.iterrows():
+                    c, l, p, v = row[['j', 'i', 'layer', 'value']].astype(str)
+                    match = r''.join(['C=', sp, c, 'L=', sp, l,
+                                      'P=', sp, p, 'V=', sp, re_num])
+                    repl = 'C={:>7}L={:>7}P={:>7}V={:>10}'.format(c, l, p, v)
                     repl_dic[match] = repl
                 # ---- stock as new line
                 new_lines.append(line)
@@ -528,8 +511,6 @@ class MarthePump():
         # ---- Write all data
         with open(self.pastp_file, 'w') as f:
             f.write(''.join(new_lines))
-
-
 
     def _write_record(self):
         """
@@ -559,7 +540,7 @@ class MarthePump():
         # ---- Set usefull regex
         re_block = r";\s*\*{3}\s*\n(.*?)/\*{5}"
         re_num = r"[-+]?\d*\.?\d+|\d+"
-        re_jikv = r"C=\s*({})L=\s*({})P=\s*({})V=\s*({});".format(*[re_num]*4)
+        re_jikv = r"C=\s*({})L=\s*({})P=\s*({})V=\s*({});".format(*[re_num] * 4)
 
         # ---- Define mode tag
         mode_tag = '/DEBIT/' if self.mode == 'aquifer' else '/Q_EXTER_RIVI/'
@@ -571,7 +552,7 @@ class MarthePump():
         for line in steady_block.splitlines(True):
             if all(s in line for s in [mode_tag + 'MAIL', 'File=']):
                 # ---- Fetch localisation infos
-                c,l,p,v = map(ast.literal_eval, re.findall(re_jikv, line)[0])
+                c, l, p, v = map(ast.literal_eval, re.findall(re_jikv, line)[0])
                 # ---- Query record DataFrame
                 q = f'i == {l} & j == {c} & layer == {p} & istep == 0'
                 new_v = rec_df.query(q)['value'].values[0]
@@ -585,17 +566,14 @@ class MarthePump():
         # ---- Rewrite transient data in external file       
         for qfilename in rec_df['qfilename'].unique():
             # ---- Read external file 
-            df = pd.read_csv(qfilename,  delim_whitespace=True)
+            df = pd.read_csv(qfilename, delim_whitespace=True)
             # ---- Set new values
             rec_df_ss = rec_df.query(f"istep != 0 & qfilename == '{qfilename}'")
             for qcol, gb in rec_df_ss.groupby('qcol'):
-                df.iloc[:,int(qcol)] = gb['value'].values
+                df.iloc[:, int(qcol)] = gb['value'].values
             # ---- Rewrite external file
             # NOTE should be updated with to_string()
-            df.to_csv(qfilename, sep = '\t',header = True,index = False)
-
-
-
+            df.to_csv(qfilename, sep='\t', header=True, index=False)
 
     def _write_listm(self):
         """
@@ -622,25 +600,23 @@ class MarthePump():
         listm_df[['layer', 'i', 'j']] = listm_df[['layer', 'i', 'j']].add(1)
 
         # ---- Write (modified) data
-        for (istep, qfilename), data in listm_df.groupby(['istep','qfilename']):
+        for (istep, qfilename), data in listm_df.groupby(['istep', 'qfilename']):
             df = pd.read_csv(qfilename, header=None, delim_whitespace=True)
             for qcol, gb in data.groupby('qcol'):
-                df.iloc[:,int(qcol)] = gb['value'].values
+                df.iloc[:, int(qcol)] = gb['value'].values
             #df.to_csv(qfilename, sep='\t', header=False, index=False)
             # format definition flexible to handle both "x, y, value" and "value, ligne, colonne, plan"
             # fixed-width format (check widths !)
             FFMT = lambda x: "{0:>20.10E} ".format(float(x))
             IFMT = lambda x: "{0:>6d} ".format(int(x))
-            fmt_dic = {'i':IFMT,'f':FFMT} 
-            formatters = [ fmt_dic[df[c].dtype.kind] for c in df]
+            fmt_dic = {'i': IFMT, 'f': FFMT}
+            formatters = [fmt_dic[df[c].dtype.kind] for c in df]
             with open(qfilename, 'w', encoding=encoding) as f:
-                    f.write(df.to_string( col_space=0,
-                                          formatters=formatters,
-                                         justify="left", header=False, index=False, 
-                                         index_names=False, 
-                                         max_rows = len(df), min_rows = len(df) ) )
-
-
+                f.write(df.to_string(col_space=0,
+                                     formatters=formatters,
+                                     justify="left", header=False, index=False,
+                                     index_names=False,
+                                     max_rows=len(df), min_rows=len(df)))
 
     def write_data(self):
         """
@@ -676,7 +652,6 @@ class MarthePump():
         # ---- Write multiple cell / single condition (listm)
         if not listm_df.empty:
             self._write_listm()
-
 
     def __str__(self):
         """

--- a/pymarthe/utils/marthe_utils.py
+++ b/pymarthe/utils/marthe_utils.py
@@ -424,19 +424,15 @@ def remove_autocal(rmafile, martfile):
             new_line  = re.sub(wrong, right, line)
             replace_text_in_file(martfile, line, new_line)
 
+def set_verbosity(martfile, silent: bool):
 
-
-
-
-def make_silent(martfile):
     """
-    Function to make marthe run silent
+    Function to run marthe model either silently or with verbose output
 
     Parameters:
     ----------
-    self : MartheModel instance
     martfile (str) : .mart file path
-                      Default is None
+    silent (bool) : silent mode or not
 
     Returns:
     --------
@@ -444,7 +440,7 @@ def make_silent(martfile):
 
     Examples:
     --------
-    make_silent('mymodel.mart')
+    set_verbosity('mymodel.mart',silent=True)
     """
     # ---- Fetch .mart file content
     with open(martfile, 'r', encoding=encoding) as f:
@@ -459,8 +455,13 @@ def make_silent(martfile):
         # ---- Make run silent 
         if exe_match is not None:
             wrong = exe_match.group()
-            right = re.sub(r'(\s|\w)=','M=', wrong)
-            new_line  = re.sub(wrong, right, line)
+
+            if silent:
+                right = re.sub(r'(\s|\w)=', 'M=', wrong)
+            else:
+                right = re.sub(r'(\s|\w)=', ' =', wrong)
+            new_line = re.sub(wrong, right, line)
+
             replace_text_in_file(martfile, line, new_line)
 
 


### PR DESCRIPTION
# Description

This PR fixes several bugs and improves some methods across the codebase.

## Bug Fixes

1. **Fixed a bug when instantiating a `MarthePump`** with a mix of river pump types — i.e., when both `TRONCON` input (via `/Q_EXTER_RIVI/TRONCON` in `.pastp`) and `MAILLE` input (via `/Q_EXTER_RIVI/LIST_MAIL`) are used simultaneously.
2. **Fixed a bug in the `get_data` method** of the `MarthePump` class, which was returning incorrectly formatted values due to the use of the built-in `list()` function. It now uses the `to_list()` method to preserve the correct float format.

## MartheField

1. **Exposed `MartheFieldSeries`** in the `__init__.py` file to simplify imports.
2. **Allowed the use of a 2D array** as an argument in the `set_data` method of the `MartheField` class.
3. **Added a type check** on the `mm` argument (expected to be a `MartheModel`) during instantiation of the `MartheField` class.  
   Previously, some methods checked the type of `mm` inside the class logic. It's now cleaner and safer to validate it at construction and remove further redundant checks.

## MartheModel

1. **Replaced the `make_silent` method** with a new method: `set_verbosity`.  
   The original `make_silent` method only wrote into the `.mart` file when `silent=True`, but didn’t write anything when `silent=False`.  
   The new `set_verbosity` method explicitly writes to the `.mart` file for both cases, allowing you to toggle verbose mode more transparently.  
   The method was also renamed for clarity and better expressiveness.

2. **Added a check on the `spatial_index` argument** when instantiating a `MartheModel`.  
   An explicit error is now raised if the spatial index files are not provided correctly.  
   By default, `Rtree.Index` silently creates an empty spatial index if files are missing — this behavior is now caught early to avoid silent failures.
