### PR TITLE
Disable sb.Popen, using now sb.run for run_model method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# Pycharm project settings
+.idea/
+
 # Rope project settings
 .ropeproject
 

--- a/pymarthe/__init__.py
+++ b/pymarthe/__init__.py
@@ -35,6 +35,7 @@ print(
 # ---- Imports from main library
 from .marthe import MartheModel
 from .mfield import MartheField
+from .mfield import MartheFieldSeries
 from .moptim import MartheOptim
 from .msoil import MartheSoil
 from .mpump import MarthePump

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -1274,14 +1274,12 @@ class MartheModel():
                 )
             )
 
-    def run_model(self, exe_name='marthe', rma_file=None, silent=False,
-                  # live_stdout=False,
-                  ):
+    def run_model(self, exe_name='marthe', rma_file=None, silent=True,):
         """
-        Run Marthe model using subprocess.Popen. It communicates 
-        with the model's stdout asynchronously and reports progress 
-        to the screen with timestamps
-        TODO : Currently only sp.run implemented. Implement Popen for futur only if needed.
+        Run Marthe model using subprocess.run. stdout and stderr are
+        not handled by this function. Actually, Marthe writes stdout
+        in bilandeb.txt and stderr in mart_ver.txt.
+
         Parameters
         ----------
         exe_name (str, optional) : Marthe executable name.
@@ -1289,14 +1287,11 @@ class MartheModel():
                                    exename is not in environment path
                                    Default is 'marthe'.
         rma_file (str, optional) : .rma file of model to run.
-        silent (bool, optional) : run marthe model as silent
-
-        Returns
-        -------
-        (success, buff)
-        success (bool) : Binary success of the run 
-        buff (list) :  stdout
+        silent (bool, optional) : whether to run Marthe quietly or not.
+        This argument can usually be True, except if you want to check the
+        output lines in the graphical Windows executable.
         """
+        
         self.set_verbosity(silent)
 
         # ---- Find executable
@@ -1310,44 +1305,29 @@ class MartheModel():
         if rma_file is None:
             rma_file = os.path.join(self.mldir, self.rma_file)
 
-        output_lines = []
-        success = False
-        normal_msg = "Fin normale du calcul"
-
         # ---- Run the model
-        if silent:
-            # Blocking mode
-            try:
-                result = sp.run([exe, rma_file], capture_output=True, text=True, check=False)
-                output_lines = result.stdout.splitlines()
-                success = any(normal_msg.lower() in line.lower() for line in output_lines)
-                if result.returncode != 0 and not success:
-                    print(f"[Erreur] Le modèle s’est terminé avec le code {result.returncode}")
-            except Exception as e:
-                print(f"[Erreur] L’exécution a échoué : {e}")
-                success = False
+        sp.run([exe, rma_file], check=True)
 
-        else:
-            # Live stdout mode
-            try:
-                with sp.Popen([exe, rma_file], stdout=sp.PIPE, stderr=sp.STDOUT, text=True, bufsize=1) as proc:
-                    for line in proc.stdout:
-                        line = line.rstrip()
-                        output_lines.append(line)
-                        print(line)
-                        if normal_msg.lower() in line.lower():
-                            success = True
-
-                    proc.wait()
-                    if proc.returncode != 0 and not success:
-                        print(f"[Erreur] Le modèle s’est terminé avec le code {proc.returncode}")
-                        success = False
-
-            except Exception as e:
-                print(f"[Erreur] Impossible d’exécuter le modèle : {e}")
-                success = False
-
-        return success, output_lines
+        # NEW POPEN BLOCK BY SMA, IN CASE IT'S NEEDED (run time issue fixed)
+        # else:
+        #     # Live stdout mode
+        #     try:
+        #         with sp.Popen([exe, rma_file], stdout=sp.PIPE, stderr=sp.STDOUT, text=True, bufsize=1) as proc:
+        #             for line in proc.stdout:
+        #                 line = line.rstrip()
+        #                 output_lines.append(line)
+        #                 print(line)
+        #                 if normal_msg.lower() in line.lower():
+        #                     success = True
+        #
+        #             proc.wait()
+        #             if proc.returncode != 0 and not success:
+        #                 print(f"[Erreur] Le modèle s’est terminé avec le code {proc.returncode}")
+        #                 success = False
+        #
+        #     except Exception as e:
+        #         print(f"[Erreur] Impossible d’exécuter le modèle : {e}")
+        #         success = False
 
         # TODO keeping the olds Popen blocks whenever it's needed
         # it decided to go back with

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -1330,8 +1330,7 @@ class MartheModel():
             rma_file = os.path.join(self.mldir, self.rma_file)
 
         if disable_popen:
-            import subprocess
-            buff = subprocess.run([exe, rma_file],capture_output=True, text=True, check=True)
+            buff = sp.run([exe, rma_file],capture_output=True, text=True, check=True)
             success = True
 
         else:

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -721,14 +721,14 @@ class MartheModel():
         """
         marthe_utils.remove_autocal(self.rma_file, self.mlfiles['mart'])
 
-    def make_silent(self):
+    def set_verbosity(self, silent: bool) -> None:
         """
-        Function to make marthe run silent
+        Function to run marthe model either silently or with verbose output
 
         Parameters:
         ----------
         self : MartheModel instance
-
+        silent : bool
         Returns:
         --------
         Write in .mart inplace
@@ -736,9 +736,9 @@ class MartheModel():
         Examples:
         --------
         mm = MartheModel(rma_file)
-        mm.make_silent()
+        mm.set_verbosity(silent=True)
         """
-        marthe_utils.make_silent(self.mlfiles['mart'])
+        marthe_utils.set_verbosity(self.mlfiles['mart'], silent)
 
     def get_outcrop(self, as_2darray=False, base=0):
         """
@@ -1309,9 +1309,8 @@ class MartheModel():
         buff = []
         normal_msg = 'normal termination'
 
-        # ---- Force model to run as silent if required
-        if silent:
-            self.make_silent()
+        # ---- Set the verbosity of the model
+        self.set_verbosity(silent)
 
         # ---- Check to make sure that program and namefile exist
         exe = which(exe_name)

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -1330,8 +1330,12 @@ class MartheModel():
             rma_file = os.path.join(self.mldir, self.rma_file)
 
         if disable_popen:
-            buff = sp.run([exe, rma_file],capture_output=True, text=True, check=True)
-            success = True
+            result = sp.run([exe, rma_file], capture_output=True, text=True, check=True)
+            buff = result.stdout.splitlines()
+            for line in buff:
+                if normal_msg in line.lower():
+                    success = True
+                    break
 
         else:
 

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -129,7 +129,7 @@ class MartheModel():
         # ---- Manage spatial index instance
         # From existing external file
         if isinstance(spatial_index, str):
-            self._check_si_files(spatial_index)
+            spatial_index = self._check_si_input(spatial_index)
             self.sifile = spatial_index
             self.si_state = 1  # activate spatial index
             from rtree.index import Index
@@ -1619,39 +1619,42 @@ class MartheModel():
                                           external=external,
                                           new_pastpfile=new_pastpfile)
 
-    def _check_si_files(self, spatial_index: str) -> None:
+    def _check_si_input(self, spatial_index: str) -> str:
         """
-        Private function for checking spatial index files. Intent to capture a
-        FileNotFoundError if index files are not found. While rtree.index.Index will
-        not return an Error but creates an empty index.Index instead.
+        Removes '.dat' or '.idx' if provde by the user.
+        Intent to capture a FileNotFoundError if index files are not found.
 
         Parameters
         ----------
         spatial_index : str
-            The relative or absolute path to the spatial index prefix file (without extension).
+            The relative or absolute path to the spatial index prefix file.
 
         Raises
         ------
-        ValueError
-            If the spatial_index string ends with '.dat' or '.idx'.
         FileNotFoundError
             If the corresponding '.dat' or '.idx' files do not exist.
+        Returns
+        ------
+            spatial_index : path to the spatial index file fixed.
         """
 
-        # Checks if spatial_index argument is valid
+        # Fix spatial_index argument if it's not valid (remove extention)
         if spatial_index.endswith(('.dat', '.idx')):
-            raise ValueError(
-                "spatial_index argument does not support extension like"
-                "'.dat' or '.idx'. \n Just provide the prefix without extension")
-        spatial_index_dat = spatial_index + ".dat"
-        spatial_index_idx = spatial_index + ".idx"
+            spatial_index_fix = spatial_index[:-4]
+        else:
+            spatial_index_fix = spatial_index
+
         # Checks if spatial_index files exist
+        spatial_index_dat = spatial_index_fix + ".dat"
+        spatial_index_idx = spatial_index_fix + ".idx"
         if (not os.path.exists(spatial_index_dat) or not
                 os.path.exists(spatial_index_idx)):
             raise FileNotFoundError(
-                f"Paths to the index files '{spatial_index_idx}' and "
-                f"'{spatial_index_dat}' do not exist."
+                f"Path or file '{os.path.join(os.getcwd(), spatial_index_idx)}' or "
+                f"'{os.path.join(os.getcwd(), spatial_index_dat)}' do not exists."
             )
+
+        return spatial_index_fix
 
     def __str__(self):
         """

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -8,7 +8,7 @@ import warnings
 import subprocess as sp
 from shutil import which
 from copy import deepcopy
-import queue 
+import queue
 import threading
 import numpy as np
 import pandas as pd
@@ -26,7 +26,8 @@ class MartheModel():
     """
     Wrapper MARTHE --> Python
     """
-    def __init__(self, rma_path, spatial_index = False, modelgrid= False):
+
+    def __init__(self, rma_path, spatial_index=False, modelgrid=False):
         """
         Parameters
         ----------
@@ -83,7 +84,7 @@ class MartheModel():
 
         """
         # ---- Get model working directory and rma file
-        self.rma_path = rma_path 
+        self.rma_path = rma_path
         self.mldir, self.rma_file = os.path.split(self.rma_path)
 
         # ---- Get model name 
@@ -97,7 +98,7 @@ class MartheModel():
         self.mldates = marthe_utils.get_dates(self.mlfiles['pastp'], self.mlfiles['mart'])
 
         # ---- Get infos about layers
-        self.nnest, self.layers_infos = marthe_utils.get_layers_infos(self.mlfiles['layer'], base = 0)
+        self.nnest, self.layers_infos = marthe_utils.get_layers_infos(self.mlfiles['layer'], base=0)
         self.nlay = self.layers_infos.layer.max() + 1
 
         # ---- Get refine levels for nested grids
@@ -110,7 +111,7 @@ class MartheModel():
         self.imask = self.build_imask()
 
         # ---- Set number of cell by layer
-        self.ncpl = int(len(self.imask.data)/self.nlay)
+        self.ncpl = int(len(self.imask.data) / self.nlay)
 
         # ---- Set number of simulated timestep
         self.nstep = len(self.mldates)
@@ -120,7 +121,7 @@ class MartheModel():
         self.load_prop('permh')
 
         # ---- Load geometry
-        self.geometry = {g : None for g in ['sepon', 'topog', 'hsubs']}
+        self.geometry = {g: None for g in ['sepon', 'topog', 'hsubs']}
 
         # ---- Set spatial reference (used for compatibility with pyemu geostat utils)
         self.spatial_reference = SpatialReference(self)
@@ -128,13 +129,14 @@ class MartheModel():
         # ---- Manage spatial index instance
         # From existing external file
         if isinstance(spatial_index, str):
-            self.si_state = 1       # activate spatial index
+            self._check_si_files(spatial_index)
+            self.sifile = spatial_index
+            self.si_state = 1  # activate spatial index
             from rtree.index import Index
             self.spatial_index = Index(spatial_index)
-            self.sifile = spatial_index
         # From custom dictionary
         elif isinstance(spatial_index, dict):
-            name = spatial_index.get('name', f'{self.mlname}_si' )
+            name = spatial_index.get('name', f'{self.mlname}_si')
             only_active = spatial_index.get('only_active', False)
             self.build_spatial_index(name, only_active)
         # From generic
@@ -142,7 +144,7 @@ class MartheModel():
             self.build_spatial_index()
         # Without 
         elif spatial_index is False:
-            self.si_state = 0       # desactivate spatial index
+            self.si_state = 0  # desactivate spatial index
             self.sifile = None
             self.spatial_index = None
 
@@ -151,9 +153,6 @@ class MartheModel():
             self.build_modelgrid()
         else:
             self.modelgrid = None
-
-
-
 
     def __iter__(self, only_active=False):
 
@@ -201,9 +200,9 @@ class MartheModel():
                     # -- For active cell
                     if r.value == 1:
                         # Store infos of current cell
-                        obj = ( node, r.layer, r.inest, r.i, r.j,
-                                r.x, r.y, r.dx, r.dy, r.dx*r.dy,
-                                r.vertices, int(r.value))
+                        obj = (node, r.layer, r.inest, r.i, r.j,
+                               r.x, r.y, r.dx, r.dy, r.dx * r.dy,
+                               r.vertices, int(r.value))
                         # Compute cell bounds ((xmin, ymin, xmax, ymax))
                         if self.si_state:
                             bounds = (*r.vertices[0], *r.vertices[2])
@@ -218,16 +217,16 @@ class MartheModel():
                     else:
                         node += 1
                     # -- Return user progress bar
-                    marthe_utils.progress_bar((node+1)/nnodes)
+                    marthe_utils.progress_bar((node + 1) / nnodes)
 
             # -- Enable insertion of inactive cells 
             else:
                 # -- Iterate over structured grid data
                 for r in records:
                     # Store infos of current cell
-                    obj = ( node, r.layer, r.inest, r.i, r.j,
-                            r.x, r.y, r.dx, r.dy, r.dx*r.dy,
-                            r.vertices, int(r.value))
+                    obj = (node, r.layer, r.inest, r.i, r.j,
+                           r.x, r.y, r.dx, r.dy, r.dx * r.dy,
+                           r.vertices, int(r.value))
                     # -- Compute cell bounds
                     if self.si_state:
                         bounds = (*r.vertices[0], *r.vertices[2])
@@ -237,10 +236,9 @@ class MartheModel():
                     else:
                         yield obj
                     # -- Return user progress bar
-                    marthe_utils.progress_bar((node+1)/nnodes)
+                    marthe_utils.progress_bar((node + 1) / nnodes)
                     # -- Incrementation of unique cell id
                     node += 1
-
 
     def build_spatial_index(self, name=None, only_active=False):
         """
@@ -276,16 +274,13 @@ class MartheModel():
         print('\nBuilding spatial index ...')
         if only_active:
             warnings.warn('Spatial index will be generated on active cells only.' \
-                ' This can produce some abnormal behaviours on spatial processes.')
+                          ' This can produce some abnormal behaviours on spatial processes.')
         si = rtree.index.Index(si_name,
                                self.__iter__(only_active=only_active),
                                properties=p)
         si.flush()
         self.sifile = si_name
         self.spatial_index = si
-
-
-
 
     def build_modelgrid(self, add_z=False):
         """
@@ -328,15 +323,15 @@ class MartheModel():
             pd.concat(
                 [pd.DataFrame.from_records(
                     mg.to_records(fmt='full')
-                    )
-                for mg in self.imask.to_grids()],
-                ignore_index=True
                 )
+                    for mg in self.imask.to_grids()],
+                ignore_index=True
+            )
             # -- Rename few columns 
             .rename(columns=dict(x='xcc', y='ycc', value='active'))
         )
         # -- Insert node ids
-        df.insert(0, 'node', np.arange(self.nlay*self.ncpl))
+        df.insert(0, 'node', np.arange(self.nlay * self.ncpl))
         df.set_index('node', drop=False)
 
         # -- Add vertical dimension information
@@ -344,15 +339,14 @@ class MartheModel():
             # -- Extract geometry top/bottom
             top, botm = map(np.ravel, self._get_top_bottom_arrays())
             # -- Insert z geometry informations in modelgrid
-            df.insert(df.columns.get_loc('ycc') + 1, 'zcc', (top-((top-botm)/2)))
-            df.insert(df.columns.get_loc('dy') + 1, 'dz', (top-botm))
+            df.insert(df.columns.get_loc('ycc') + 1, 'zcc', (top - ((top - botm) / 2)))
+            df.insert(df.columns.get_loc('dy') + 1, 'dz', (top - botm))
             df.insert(df.columns.get_loc('area') + 1, 'bottom', botm)
             df.insert(df.columns.get_loc('area') + 1, 'top', top)
             df.insert(df.columns.get_loc('area') + 1, 'volume', df.dx * df.dy * df.dz)
 
         # -- Set DataFrame to .modelgrid attribute
         self.modelgrid = df
-
 
     def _get_top_bottom_arrays(self):
         """
@@ -379,7 +373,7 @@ class MartheModel():
             except:
                 arr = arr_dc.reshape((self.nlay, self.ncpl))
             # -- Set masked values to nan
-            arr.setflags(write=1) # turn to mutable array
+            arr.setflags(write=1)  # turn to mutable array
             arr[np.isin(arr, mv)] = np.nan
             # -- Fill 2-items list
             geom_arrs.append(arr)
@@ -395,8 +389,8 @@ class MartheModel():
             _sepon[np.isin(_sepon, mv)] = np.nan
 
         # -- Load outcrop layer ids
-        _outcrop = self.get_outcrop().data['value'].reshape((self.nlay, self.ncpl)) # outcrop array
-        _outcrop[np.isin(_outcrop,  [9999, -9999])] = np.nan
+        _outcrop = self.get_outcrop().data['value'].reshape((self.nlay, self.ncpl))  # outcrop array
+        _outcrop[np.isin(_outcrop, [9999, -9999])] = np.nan
 
         # -- Build a empty top array with right shape 
         _top = np.empty((self.nlay, self.ncpl))
@@ -408,12 +402,12 @@ class MartheModel():
                 if self.hws == 'explicit':
                     arrs = [_hsubs[:ilay, icell], _topog[:1, icell]]
                 else:
-                    arrs = [ _hsubs[:ilay, icell], _sepon[:ilay+1, icell], _topog[:1, icell]]
+                    arrs = [_hsubs[:ilay, icell], _sepon[:ilay + 1, icell], _topog[:1, icell]]
                 # -- Compute z minimum above substratum
                 ztop = np.fmin.reduce(np.concatenate(arrs))
                 # -- If current cell's top is outcroping
                 if np.isnan(ztop):
-                    oc = np.fmax.reduce(_outcrop[:ilay+1, icell])
+                    oc = np.fmax.reduce(_outcrop[:ilay + 1, icell])
                     if np.isnan(oc):
                         ztop = np.nan
                     elif ilay <= int(oc):
@@ -425,8 +419,6 @@ class MartheModel():
 
         # -- Return top and botm arrays
         return _top, _hsubs
-
-
 
     def load_geometry(self, g=None, **kwargs):
         """
@@ -462,13 +454,11 @@ class MartheModel():
 
         # ---- Load geometry as MartheField instance
         for g in _g:
-            self.geometry[g] = MartheField(g, 
-                                          self.mlfiles[g],
-                                          self,
-                                          use_imask=kwargs.get('use_imask', False)
-                                          )
-
-
+            self.geometry[g] = MartheField(g,
+                                           self.mlfiles[g],
+                                           self,
+                                           use_imask=kwargs.get('use_imask', False)
+                                           )
 
     def build_imask(self):
         """
@@ -495,8 +485,6 @@ class MartheModel():
         imask.data['value'] = (imask.data['value'] != 0).astype(int)
         # ---- Return MartheField instance
         return imask
-
-
 
     def load_prop(self, prop, **kwargs):
         """
@@ -537,10 +525,10 @@ class MartheModel():
 
         # ---- Manage pumping
         elif prop == 'aqpump':
-            self.prop[prop] = MarthePump(self, mode = 'aquifer', **kwargs)
+            self.prop[prop] = MarthePump(self, mode='aquifer', **kwargs)
 
         elif prop == 'rivpump':
-            self.prop[prop] = MarthePump(self, mode = 'river', **kwargs)
+            self.prop[prop] = MarthePump(self, mode='river', **kwargs)
 
         # ---- Manage soil property
         elif prop == 'soil':
@@ -549,9 +537,6 @@ class MartheModel():
         # ---- Not supported property
         else:
             print(f"Property `{prop}` not supported.")
-
-
-
 
     def write_prop(self, prop=None):
         """
@@ -592,9 +577,6 @@ class MartheModel():
         for p in props:
             self.prop[p].write_data()
 
-
-
-
     @classmethod
     def from_config(cls, configfile):
         """
@@ -633,26 +615,25 @@ class MartheModel():
             if pdic['type'] == 'list':
                 #if not prop in mm.prop.keys():
                 mm.load_prop(prop)
-                mm.prop[prop].set_data_from_parfile(parfile = os.path.normpath(pdic['parfile']),
-                                                    keys = pdic['keys'].split(','),
-                                                    value_col = pdic['value_col'],
-                                                    btrans = pdic['btrans'])
+                mm.prop[prop].set_data_from_parfile(parfile=os.path.normpath(pdic['parfile']),
+                                                    keys=pdic['keys'].split(','),
+                                                    value_col=pdic['value_col'],
+                                                    btrans=pdic['btrans'])
             # -- Set grid-like properties
             elif pdic['type'] == 'grid':
                 #if not prop in mm.prop.keys():
-                use_imask = pdic['use_imask']=='True'
-                mm.load_prop(prop,use_imask=use_imask)
+                use_imask = pdic['use_imask'] == 'True'
+                mm.load_prop(prop, use_imask=use_imask)
                 # -- Get izone as MartheField instance
                 izone = MartheField(f'i{prop}', os.path.normpath(pdic['izone']), mm, use_imask=use_imask)
                 # -- Set all field values (zpc and pp)
-                for pf in  pdic['parfile'].split(','):
-                    mm.prop[prop].set_data_from_parfile(parfile= os.path.normpath(pf),
-                                                        izone= izone,
-                                                        btrans= pdic['btrans'])
+                for pf in pdic['parfile'].split(','):
+                    mm.prop[prop].set_data_from_parfile(parfile=os.path.normpath(pf),
+                                                        izone=izone,
+                                                        btrans=pdic['btrans'])
 
         # -- Return MartheModel instance
         return mm
-
 
     def get_extent(self):
         """
@@ -672,15 +653,13 @@ class MartheModel():
         if self.spatial_index is None:
             mg0 = self.imask.to_grids(layer=0)[0]
             xmin, ymin = mg0.xl, mg0.yl
-            xmax, ymax = mg0.xl+mg0.Lx, mg0.yl+mg0.Ly
+            xmax, ymax = mg0.xl + mg0.Lx, mg0.yl + mg0.Ly
             extent = [xmin, ymin, xmax, ymax]
         # -- Extract extent from spatial index
         else:
             extent = self.spatial_index.bounds
         # -- Return
         return extent
-
-
 
     def get_edges(self, closed=False):
         """
@@ -719,10 +698,6 @@ class MartheModel():
         # -- Return
         return edges
 
-
-
-
-
     def remove_autocal(self):
         """
         Function to make marthe auto calibration silent.
@@ -741,9 +716,7 @@ class MartheModel():
         mm = MartheModel(rma_file)
         mm.remove_autocal()
         """
-        marthe_utils.remove_autocal(self.rma_file, self.mlfiles['mart'])    
-
-
+        marthe_utils.remove_autocal(self.rma_file, self.mlfiles['mart'])
 
     def make_silent(self):
         """
@@ -762,9 +735,7 @@ class MartheModel():
         mm = MartheModel(rma_file)
         mm.make_silent()
         """
-        marthe_utils.make_silent(self.mlfiles['mart']) 
-
-
+        marthe_utils.make_silent(self.mlfiles['mart'])
 
     def get_outcrop(self, as_2darray=False, base=0):
         """
@@ -823,15 +794,13 @@ class MartheModel():
                 .min()['layer']
             )
             # -- Building Marthefield object response
-            outcrop =  MartheField('outcrop', 9999, self)
+            outcrop = MartheField('outcrop', 9999, self)
             # -- Set inactive cell to 9999 instead of 0 for plotting (and understanding) purpose 
             outcrop.data['value'][~mask] = 9999
             # -- Set layer ids values previously calculated
             outcrop.data['value'][oc.index] = oc.values
             # -- Return MartheField instance
             return outcrop
-
-
 
     def query_grid(self, target=None, **kwargs):
         """
@@ -877,12 +846,12 @@ class MartheModel():
             self.build_modelgrid()
 
         # -- Make all kwargs values iterable
-        d = {k:marthe_utils.make_iterable(v) for k,v in kwargs.items()}
+        d = {k: marthe_utils.make_iterable(v) for k, v in kwargs.items()}
 
         # -- Check kwargs names validity
         nf = [f"'{kw}'" for kw in d.keys() if kw not in self.modelgrid.columns]
         err_msg = 'ERROR : some query names not found in ' \
-                   'modelgrid : {}.'.format(', '.join(nf))
+                  'modelgrid : {}.'.format(', '.join(nf))
         assert len(nf) == 0, err_msg
 
         # -- Check kwargs values validity
@@ -903,16 +872,14 @@ class MartheModel():
         # -- Check target validity
         nf = [f"'{t}'" for t in target if t not in self.modelgrid.set_index(kidx).columns]
         err_msg = 'ERROR : some `target` values not found in ' \
-                   'modelgrid or already use for grid query: {}.'.format(', '.join(nf))
+                  'modelgrid or already use for grid query: {}.'.format(', '.join(nf))
         assert len(nf) == 0, err_msg
 
         # -- Query modelgrid DataFrame
-        df = self.modelgrid.set_index(kidx).loc[vidx,target]
+        df = self.modelgrid.set_index(kidx).loc[vidx, target]
 
         # -- Return subset DataFrame
         return df
-
-
 
     def isin_extent(self, x, y):
         """
@@ -936,12 +903,10 @@ class MartheModel():
         # -- Get model domain extension as polygon
         ext = self.get_edges(closed=True)
         # -- Make coords iterable
-        _x,_y = [np.array(marthe_utils.make_iterable(coord)) for coord in [x,y]]
+        _x, _y = [np.array(marthe_utils.make_iterable(coord)) for coord in [x, y]]
         res = shp_utils.point_in_polygon(_x, _y, ext)
         # -- Return boolean response
         return res
-
-
 
     def get_node(self, x, y, layer=None, only_active=False):
         """
@@ -970,7 +935,7 @@ class MartheModel():
         
         """
         # -- Manage xy coordinates
-        _x, _y = [marthe_utils.make_iterable(var) for var in [x,y]]
+        _x, _y = [marthe_utils.make_iterable(var) for var in [x, y]]
 
         # -- Check if xy-coordinates are in model extension
         inext = self.isin_extent(_x, _y)
@@ -991,7 +956,7 @@ class MartheModel():
                 for ix, iy in zip(_x, _y):
                     inodes = []
                     # -- Intercept spatial index on objects only (slower)
-                    for hit in sorted(self.spatial_index.intersection((ix,iy), objects='raw')):
+                    for hit in sorted(self.spatial_index.intersection((ix, iy), objects='raw')):
                         # -- Verify whatever the cell is active
                         if hit[-1] == 1:
                             inodes.append(hit[0])
@@ -1000,14 +965,14 @@ class MartheModel():
                     nodes.append(inodes)
             else:
                 # -- Intercept spatial index on node id only (faster)
-                nodes = [sorted(self.spatial_index.intersection((ix,iy))) for ix, iy in zip(_x, _y)]
+                nodes = [sorted(self.spatial_index.intersection((ix, iy))) for ix, iy in zip(_x, _y)]
 
         else:
             # -- Manage layer input
             _layer = marthe_utils.make_iterable(layer)
 
             # ---- Allowed layer to be a simple integer for all xy-coordinates
-            if (len(_layer) == 1) and (len(_x) > 1) :
+            if (len(_layer) == 1) and (len(_x) > 1):
                 _layer = list(_layer) * len(_x)
 
             # ---- Assertion on variables length
@@ -1018,7 +983,7 @@ class MartheModel():
             nodes = []
             for ix, iy, ilay in zip(_x, _y, _layer):
                 # -- Intercept spatial index on objects only (slower)
-                for hit in self.spatial_index.intersection((ix,iy), objects='raw'):
+                for hit in self.spatial_index.intersection((ix, iy), objects='raw'):
                     # -- Verify in intersect required layer
                     if hit[1] == ilay:
                         if only_active:
@@ -1031,8 +996,6 @@ class MartheModel():
                             nodes.append(hit[0])
         # -- Return nodes
         return nodes
-
-
 
     def all_active(self, node):
         """
@@ -1058,9 +1021,6 @@ class MartheModel():
         # -- Return
         return res
 
-
-
-
     def any_active(self, node):
         """
         Check whatever a node or a serie of node contains at least 1 active.
@@ -1084,8 +1044,6 @@ class MartheModel():
         res = any(x > 0 for x in self.imask.data['value'][n])
         # -- Return
         return res
-
-
 
     @marthe_utils.deprecated
     def get_ij(self, x, y, stack=False):
@@ -1116,7 +1074,7 @@ class MartheModel():
 
         """
         # ---- Make i and j iterable
-        _x, _y = [marthe_utils.make_iterable(var) for var in [x,y]]
+        _x, _y = [marthe_utils.make_iterable(var) for var in [x, y]]
 
         # ---- Assert that i and j have the same length
         err_msg = "ERROR: x and y must have the same length." \
@@ -1130,14 +1088,12 @@ class MartheModel():
 
         # ---- Manage output
         if len(_x) == 1:
-            out = np.column_stack([i,j]) if stack else (i[0], j[0])
+            out = np.column_stack([i, j]) if stack else (i[0], j[0])
         else:
-            out = np.column_stack([i,j]) if stack else (i, j)
+            out = np.column_stack([i, j]) if stack else (i, j)
 
         # ---- Return coordinates
         return out
-
-
 
     @marthe_utils.deprecated
     def get_xy(self, i, j, stack=False):
@@ -1165,7 +1121,7 @@ class MartheModel():
         coords = mm.get_ij(i,j, stack=True)
         """
         # ---- Make i and j iterable
-        _i, _j = [marthe_utils.make_iterable(var) for var in [i,j]]
+        _i, _j = [marthe_utils.make_iterable(var) for var in [i, j]]
 
         # ---- Assert that i and j have the same length
         err_msg = "ERROR: i and j must have the same length." \
@@ -1175,7 +1131,7 @@ class MartheModel():
         # ---- Subset data by pairs on first layer
         df = pd.DataFrame.from_records(self.imask.get_data(layer=0))
         df['temp'] = df['i'].astype(str) + '_' + df['j'].astype(str)
-        df_ss = df.loc[df.temp.isin([f'{ii}_{jj}' for ii,jj in zip(_i,_j)])]
+        df_ss = df.loc[df.temp.isin([f'{ii}_{jj}' for ii, jj in zip(_i, _j)])]
 
         # ---- Fetch corresponding xcc, ycc
         x, y = [df_ss[c].to_numpy() for c in list('xy')]
@@ -1185,11 +1141,9 @@ class MartheModel():
             out = np.column_stack([x, y]) if stack else (x[0], y[0])
         else:
             out = np.column_stack([x, y]) if stack else (x, y)
-        
+
         # ---- Return coordinates
         return out
-
-
 
     def extract_refine_levels(self):
         """
@@ -1214,18 +1168,15 @@ class MartheModel():
         """
         # -- Read 'permh' with adjacent cells (layer 0)
         mgs = marthe_utils.read_grid_file(
-                    self.mlfiles['permh'],
-                        keep_adj=True)
+            self.mlfiles['permh'],
+            keep_adj=True)
         mgs0 = [mg for mg in mgs if mg.layer == 0]
         # -- Compute rlevel (dx_main_grid / dx_nested_grid)
-        rlevels = {mg.inest : int(mg.dx[0]//mg.dx[1])
-                                if mg.inest > 0 else None
-                                    for mg in mgs0}
+        rlevels = {mg.inest: int(mg.dx[0] // mg.dx[1])
+        if mg.inest > 0 else None
+                   for mg in mgs0}
         # -- Return
         return rlevels
-
-
-
 
     def get_xycellcenters(self, stack=False):
         """
@@ -1260,8 +1211,6 @@ class MartheModel():
             return np.column_stack([xcc, ycc])
         else:
             return xcc, ycc
-
-
 
     def get_layer_from_depth(self, x, y, depth, as_list=True):
         """
@@ -1317,15 +1266,12 @@ class MartheModel():
                          depth=_d,
                          layer=layers,
                          name=self.layers_infos.loc[layers, 'name'])
-                    )
                 )
+            )
 
-
-
-
-    def run_model(self,exe_name = 'marthe', rma_file = None, 
-                      silent = True, verbose=False, pause=False,
-                      report=False, cargs=None):
+    def run_model(self, exe_name='marthe', rma_file=None,
+                  silent=True, verbose=False, pause=False,
+                  report=False, cargs=None):
         """
         Run Marthe model using subprocess.Popen. It communicates 
         with the model's stdout asynchronously and reports progress 
@@ -1358,7 +1304,7 @@ class MartheModel():
         # ---- Initialize variable
         success = False
         buff = []
-        normal_msg='normal termination'
+        normal_msg = 'normal termination'
 
         # ---- Force model to run as silent if required
         if silent:
@@ -1370,16 +1316,15 @@ class MartheModel():
             # -- Try which() function for window user 
             import platform
             if platform.system() in 'Windows':
-                    exe = which(exe_name + '.exe')
+                exe = which(exe_name + '.exe')
 
         if exe is None:
             s = 'The program {} does not exist or is not executable.'.format(
                 exe_name)
             raise Exception(s)
-        
 
         # ---- Fetch Marthe .rma file if not provided
-        if rma_file is None : 
+        if rma_file is None:
             rma_file = os.path.join(self.mldir, self.rma_file)
 
         # ---- Simple function for the thread to target
@@ -1448,12 +1393,9 @@ class MartheModel():
             input('Press Enter to continue...')
         return success, buff
 
-
-
-
-    def get_vtk(self, vertical_exageration=0.05, hws = None,
-                      smooth=False, binary=True, xml=False,
-                      shared_points=False):
+    def get_vtk(self, vertical_exageration=0.05, hws=None,
+                smooth=False, binary=True, xml=False,
+                shared_points=False):
 
         """
         Build vtk unstructured grid from model geometry.
@@ -1512,8 +1454,6 @@ class MartheModel():
         # -- Return vtk instance
         return vtk
 
-
-
     def show_run_times(self, logfile=None, tablefmt='fancy'):
         """
         Print model run times.
@@ -1539,8 +1479,8 @@ class MartheModel():
 
         # -- Assert log file exists
         err_msg = f"Could not found {lf} log file. " \
-                   "Make sure to run the model before " \
-                   "calling `.show_run_times()` method."
+                  "Make sure to run the model before " \
+                  "calling `.show_run_times()` method."
         assert os.path.exists(lf), err_msg
 
         # -- Extract run times per process
@@ -1554,9 +1494,6 @@ class MartheModel():
         except:
             # -- Classic table print
             print(df)
-        
-
-
 
     def get_time_window(self, tw_type='date'):
         """
@@ -1585,13 +1522,11 @@ class MartheModel():
 
         """
         # ---- Extract time window
-        tw_min, tw_max =  marthe_utils.get_tw(martfile= self.mlfiles['mart'],
-                                              pastpfile= self.mlfiles['pastp'],
-                                              tw_type=tw_type)
+        tw_min, tw_max = marthe_utils.get_tw(martfile=self.mlfiles['mart'],
+                                             pastpfile=self.mlfiles['pastp'],
+                                             tw_type=tw_type)
         # ---- Return time window as tuple
         return tw_min, tw_max
-
-
 
     def set_time_window(self, start=None, end=None):
         """
@@ -1628,13 +1563,10 @@ class MartheModel():
 
         """
         # ---- Wrapper to utils
-        marthe_utils.set_tw( start= start,
-                             end= end,
-                             martfile= self.mlfiles['mart'],
-                             pastpfile= self.mlfiles['pastp'] )
-
-
-
+        marthe_utils.set_tw(start=start,
+                            end=end,
+                            martfile=self.mlfiles['mart'],
+                            pastpfile=self.mlfiles['pastp'])
 
     def set_hydrodyn_periodicity(self, istep, external=False, new_pastpfile=None):
         """
@@ -1680,11 +1612,44 @@ class MartheModel():
 
         """
         # ---- Wrapper to utils
-        marthe_utils.hydrodyn_periodicity(pastpfile= self.mm.mlfiles['pastp'],
-                                          istep= istep,
-                                          external= external,
-                                          new_pastpfile= new_pastpfile)
+        marthe_utils.hydrodyn_periodicity(pastpfile=self.mm.mlfiles['pastp'],
+                                          istep=istep,
+                                          external=external,
+                                          new_pastpfile=new_pastpfile)
 
+    def _check_si_files(self, spatial_index: str) -> None:
+        """
+        Private function for checking spatial index files. Intent to capture a
+        FileNotFoundError if index files are not found. While rtree.index.Index will
+        not return an Error, it creates an empty index.Index instead.
+
+        Parameters
+        ----------
+        spatial_index : str
+            The path to the spatial index prefix file (without extension).
+
+        Raises
+        ------
+        ValueError
+            If the spatial_index string ends with '.dat' or '.idx'.
+        FileNotFoundError
+            If the corresponding '.dat' or '.idx' files do not exist.
+        """
+
+        # Checks if spatial_index argument is valid
+        if spatial_index.endswith(('.dat', '.idx')):
+            raise ValueError(
+                "spatial_index argument does not support extension like"
+                "'.dat' or '.idx'. \n Just provide the prefix without extension")
+        spatial_index_dat = spatial_index + ".dat"
+        spatial_index_idx = spatial_index + ".idx"
+        # Checks if spatial_index files exist
+        if (not os.path.exists(spatial_index_dat) or not
+                os.path.exists(spatial_index_idx)):
+            raise FileNotFoundError(
+                f"Paths to the index files '{spatial_index_idx}' and "
+                f"'{spatial_index_dat}' do not exist."
+            )
 
     def __str__(self):
         """
@@ -1693,11 +1658,11 @@ class MartheModel():
         return 'MartheModel'
 
 
-
 class SpatialReference():
     """
     Inspired from FloPy, for compatibility with PyEMU
     """
+
     def __init__(self, mm):
         """
         Parameters
@@ -1707,10 +1672,8 @@ class SpatialReference():
         mg = mm.imask.to_grids(layer=0, inest=0)[0]
         self.nrow, self.ncol = mg.nrow, mg.ncol
 
-
     def __str__(self):
         """
         Internal string method.
         """
         return 'SpatialReference'
-

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -1272,7 +1272,7 @@ class MartheModel():
                 )
             )
 
-    def run_model(self, exe_name='marthe', rma_file=None,
+    def run_model(self, exe_name='marthe', rma_file=None, disable_popen=False,
                   silent=True, verbose=False, pause=False,
                   report=False, cargs=None):
         """
@@ -1329,70 +1329,78 @@ class MartheModel():
         if rma_file is None:
             rma_file = os.path.join(self.mldir, self.rma_file)
 
-        # ---- Simple function for the thread to target
-        def q_output(output, q):
-            for line in iter(output.readline, b''):
-                q.put(line)
+        if disable_popen:
+            import subprocess
+            buff = subprocess.run([exe, rma_file],capture_output=True, text=True, check=True)
+            success = True
 
-        # ---- Create a list of arguments to pass to Popen
-        argv = [exe_name]
-        if rma_file is not None:
-            argv.append(rma_file)
+        else:
 
-        # ---- Add additional arguments to Popen arguments
-        if cargs is not None:
-            cargs = [arg for arg in cargs if isinstance(cargs, str)]
-            for t in cargs:
-                argv.append(t)
+            # ---- Simple function for the thread to target
+            def q_output(output, q):
+                for line in iter(output.readline, b''):
+                    q.put(line)
 
-        # ---- Run the model with Popen
-        proc = sp.Popen(argv, stdout=sp.PIPE, stderr=sp.STDOUT)
+            # ---- Create a list of arguments to pass to Popen
+            argv = [exe_name]
+            if rma_file is not None:
+                argv.append(rma_file)
 
-        # ---- Some tricks for the async stdout reading
-        q = queue.Queue()
-        thread = threading.Thread(target=q_output, args=(proc.stdout, q))
-        thread.daemon = True
-        thread.start()
-        failed_words = ["fail", "error"]
-        last = datetime.now()
-        lastsec = 0.
-        while True:
-            try:
-                line = q.get_nowait()
-            except queue.Empty:
-                pass
-            else:
-                if line == '':
+            # ---- Add additional arguments to Popen arguments
+            if cargs is not None:
+                cargs = [arg for arg in cargs if isinstance(cargs, str)]
+                for t in cargs:
+                    argv.append(t)
+
+            # ---- Run the model with Popen
+            proc = sp.Popen(argv, stdout=sp.PIPE, stderr=sp.STDOUT)
+
+            # ---- Some tricks for the async stdout reading
+            q = queue.Queue()
+            thread = threading.Thread(target=q_output, args=(proc.stdout, q))
+            thread.daemon = True
+            thread.start()
+            failed_words = ["fail", "error"]
+            last = datetime.now()
+            lastsec = 0.
+            while True:
+                try:
+                    line = q.get_nowait()
+                except queue.Empty:
+                    pass
+                else:
+                    if line == '':
+                        break
+                    line = line.decode('latin-1').lower().strip()
+                    if line != '':
+                        now = datetime.now()
+                        dt = now - last
+                        tsecs = dt.total_seconds() - lastsec
+                        line = "elapsed:{0}-->{1}".format(tsecs, line)
+                        lastsec = tsecs + lastsec
+                        buff.append(line)
+                        if not verbose:
+                            print(line)
+                        for fword in failed_words:
+                            if fword in line:
+                                success = False
+                                break
+                if proc.poll() is not None:
                     break
-                line = line.decode('latin-1').lower().strip()
-                if line != '':
-                    now = datetime.now()
-                    dt = now - last
-                    tsecs = dt.total_seconds() - lastsec
-                    line = "elapsed:{0}-->{1}".format(tsecs, line)
-                    lastsec = tsecs + lastsec
-                    buff.append(line)
-                    if not verbose:
-                        print(line)
-                    for fword in failed_words:
-                        if fword in line:
-                            success = False
-                            break
-            if proc.poll() is not None:
-                break
-        proc.wait()
-        thread.join(timeout=1)
-        buff.extend(proc.stdout.readlines())
-        proc.stdout.close()
-        # -- Examine run buff
-        for line in buff:
-            if normal_msg in line:
-                print("success")
-                success = True
-                break
+            proc.wait()
+            thread.join(timeout=1)
+            buff.extend(proc.stdout.readlines())
+            proc.stdout.close()
+            # -- Examine run buff
+            for line in buff:
+                if normal_msg in line:
+                    print("success")
+                    success = True
+                    break
 
-        if pause:
-            input('Press Enter to continue...')
+            if pause:
+                input('Press Enter to continue...')
+
         return success, buff
 
     def get_vtk(self, vertical_exageration=0.05, hws=None,

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -3,16 +3,18 @@ Contains the MartheModel and Spatial Reference classes.
 Designed for structured and nested grid.
 """
 
-import os, sys
+import os
+import platform
 import warnings
 import subprocess as sp
 from shutil import which
 from copy import deepcopy
-import queue
-import threading
+# import queue
+# import threading
+# from datetime import datetime
+
 import numpy as np
 import pandas as pd
-from datetime import datetime
 
 from .mfield import MartheField
 from .mpump import MarthePump
@@ -1272,14 +1274,14 @@ class MartheModel():
                 )
             )
 
-    def run_model(self, exe_name='marthe', rma_file=None, disable_popen=False,
-                  silent=True, verbose=False, pause=False,
-                  report=False, cargs=None):
+    def run_model(self, exe_name='marthe', rma_file=None, silent=True,
+                  #live_stdout=False,
+                  ):
         """
         Run Marthe model using subprocess.Popen. It communicates 
         with the model's stdout asynchronously and reports progress 
         to the screen with timestamps
-
+        TODO : Currently only sp.run implemented. Implement Popen for futur only if needed.
         Parameters
         ----------
         exe_name (str, optional) : Marthe executable name.
@@ -1287,16 +1289,7 @@ class MartheModel():
                                    exename is not in environment path
                                    Default is 'marthe'.
         rma_file (str, optional) : .rma file of model to run.
-        silent (bool, optional) : run marthe model as silent 
-        verbose (bool, optional) : echo run information to screen
-                                   Default is False.
-        pause (bool, optional) : pause upon completion
-                                 Default is False.
-        report (bool, optional) : save stdout lines to a list (buff) 
-                                  which is returned by the method
-                                  Default is True.
-        cargs (str/list, optional) : additional command line arguments to pass to the executable.
-                                     Default is None.
+        silent (bool, optional) : run marthe model as silent
 
         Returns
         -------
@@ -1304,107 +1297,121 @@ class MartheModel():
         success (bool) : Binary success of the run 
         buff (list) :  stdout
         """
-        # ---- Initialize variable
-        success = False
-        buff = []
-        normal_msg = 'normal termination'
-
-        # ---- Set the verbosity of the model
         self.set_verbosity(silent)
-
-        # ---- Check to make sure that program and namefile exist
+        # ---- Find executable
         exe = which(exe_name)
+        if exe is None and platform.system() == 'Windows':
+            exe = which(exe_name + '.exe')
         if exe is None:
-            # -- Try which() function for window user 
-            import platform
-            if platform.system() in 'Windows':
-                exe = which(exe_name + '.exe')
+            raise FileNotFoundError(f"The program {exe_name} does not exist or is not executable.")
 
-        if exe is None:
-            s = 'The program {} does not exist or is not executable.'.format(
-                exe_name)
-            raise Exception(s)
-
-        # ---- Fetch Marthe .rma file if not provided
+        # ---- Determine rma file
         if rma_file is None:
             rma_file = os.path.join(self.mldir, self.rma_file)
 
-        if disable_popen:
+        # ---- Run the model (blocking)
+        try:
             result = sp.run([exe, rma_file], capture_output=True, text=True, check=True)
-            buff = result.stdout.splitlines()
-            for line in buff:
-                if normal_msg in line.lower():
-                    success = True
-                    break
+            output_lines = result.stdout.splitlines()
+            print("STDOUT:\n", result.stdout)
+            print("STDERR:\n", result.stderr)
+            success = any('normal termination' in line.lower() for line in output_lines)
+            print("je suis jackie",output_lines)
+        except sp.CalledProcessError as e:
+            output_lines = e.stdout.splitlines() if e.stdout else []
+            print(f"Model failed: {e.returncode}\n{e.stderr}")
+            success = False
 
-        else:
+        return success, output_lines
+        # # TODO sma Popen blocks
+        # else:
+        #     # ---- Run the model with real-time output
+        #     try:
+        #         with sp.Popen([exe, rma_file], stdout=sp.PIPE, stderr=sp.STDOUT, text=True) as proc:
+        #             for line in proc.stdout:
+        #                 line = line.rstrip()
+        #                 output_lines.append(line)
+        #                 print(line)
+        #                 if normal_msg in line.lower():
+        #                     success = True
+        #             proc.wait()
+        #             if proc.returncode != 0 and not success:
+        #                 print(f"Model exited with return code {proc.returncode}")
+        #                 success = False
+        #     except Exception as e:
+        #         print(f"Failed to run model: {e}")
+        #         success = False
 
-            # ---- Simple function for the thread to target
-            def q_output(output, q):
-                for line in iter(output.readline, b''):
-                    q.put(line)
 
-            # ---- Create a list of arguments to pass to Popen
-            argv = [exe_name]
-            if rma_file is not None:
-                argv.append(rma_file)
-
-            # ---- Add additional arguments to Popen arguments
-            if cargs is not None:
-                cargs = [arg for arg in cargs if isinstance(cargs, str)]
-                for t in cargs:
-                    argv.append(t)
-
-            # ---- Run the model with Popen
-            proc = sp.Popen(argv, stdout=sp.PIPE, stderr=sp.STDOUT)
-
-            # ---- Some tricks for the async stdout reading
-            q = queue.Queue()
-            thread = threading.Thread(target=q_output, args=(proc.stdout, q))
-            thread.daemon = True
-            thread.start()
-            failed_words = ["fail", "error"]
-            last = datetime.now()
-            lastsec = 0.
-            while True:
-                try:
-                    line = q.get_nowait()
-                except queue.Empty:
-                    pass
-                else:
-                    if line == '':
-                        break
-                    line = line.decode('latin-1').lower().strip()
-                    if line != '':
-                        now = datetime.now()
-                        dt = now - last
-                        tsecs = dt.total_seconds() - lastsec
-                        line = "elapsed:{0}-->{1}".format(tsecs, line)
-                        lastsec = tsecs + lastsec
-                        buff.append(line)
-                        if not verbose:
-                            print(line)
-                        for fword in failed_words:
-                            if fword in line:
-                                success = False
-                                break
-                if proc.poll() is not None:
-                    break
-            proc.wait()
-            thread.join(timeout=1)
-            buff.extend(proc.stdout.readlines())
-            proc.stdout.close()
-            # -- Examine run buff
-            for line in buff:
-                if normal_msg in line:
-                    print("success")
-                    success = True
-                    break
-
-            if pause:
-                input('Press Enter to continue...')
-
-        return success, buff
+        # TODO keeping the olds Popen blocks whenever it's needed
+        # it decided to go back with
+        # else:
+        #
+        #     # ---- Simple function for the thread to target
+        #     def q_output(output, q):
+        #         for line in iter(output.readline, b''):
+        #             q.put(line)
+        #
+        #     # ---- Create a list of arguments to pass to Popen
+        #     argv = [exe_name]
+        #     if rma_file is not None:
+        #         argv.append(rma_file)
+        #
+        #     # ---- Add additional arguments to Popen arguments
+        #     if cargs is not None:
+        #         cargs = [arg for arg in cargs if isinstance(cargs, str)]
+        #         for t in cargs:
+        #             argv.append(t)
+        #
+        #     # ---- Run the model with Popen
+        #     proc = sp.Popen(argv, stdout=sp.PIPE, stderr=sp.STDOUT)
+        #
+        #     # ---- Some tricks for the async stdout reading
+        #     q = queue.Queue()
+        #     thread = threading.Thread(target=q_output, args=(proc.stdout, q))
+        #     thread.daemon = True
+        #     thread.start()
+        #     failed_words = ["fail", "error"]
+        #     last = datetime.now()
+        #     lastsec = 0.
+        #     while True:
+        #         try:
+        #             line = q.get_nowait()
+        #         except queue.Empty:
+        #             pass
+        #         else:
+        #             if line == '':
+        #                 break
+        #             line = line.decode('latin-1').lower().strip()
+        #             if line != '':
+        #                 now = datetime.now()
+        #                 dt = now - last
+        #                 tsecs = dt.total_seconds() - lastsec
+        #                 line = "elapsed:{0}-->{1}".format(tsecs, line)
+        #                 lastsec = tsecs + lastsec
+        #                 buff.append(line)
+        #                 if not verbose:
+        #                     print(line)
+        #                 for fword in failed_words:
+        #                     if fword in line:
+        #                         success = False
+        #                         break
+        #         if proc.poll() is not None:
+        #             break
+        #     proc.wait()
+        #     thread.join(timeout=1)
+        #     buff.extend(proc.stdout.readlines())
+        #     proc.stdout.close()
+        #     # -- Examine run buff
+        #     for line in buff:
+        #         if normal_msg in line:
+        #             print("success")
+        #             success = True
+        #             break
+        #
+        #     if pause:
+        #         input('Press Enter to continue...')
+        # return success, buff
 
     def get_vtk(self, vertical_exageration=0.05, hws=None,
                 smooth=False, binary=True, xml=False,

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -1274,8 +1274,8 @@ class MartheModel():
                 )
             )
 
-    def run_model(self, exe_name='marthe', rma_file=None, silent=True,
-                  #live_stdout=False,
+    def run_model(self, exe_name='marthe', rma_file=None, silent=False,
+                  # live_stdout=False,
                   ):
         """
         Run Marthe model using subprocess.Popen. It communicates 
@@ -1298,6 +1298,7 @@ class MartheModel():
         buff (list) :  stdout
         """
         self.set_verbosity(silent)
+
         # ---- Find executable
         exe = which(exe_name)
         if exe is None and platform.system() == 'Windows':
@@ -1309,39 +1310,44 @@ class MartheModel():
         if rma_file is None:
             rma_file = os.path.join(self.mldir, self.rma_file)
 
-        # ---- Run the model (blocking)
-        try:
-            result = sp.run([exe, rma_file], capture_output=True, text=True, check=True)
-            output_lines = result.stdout.splitlines()
-            print("STDOUT:\n", result.stdout)
-            print("STDERR:\n", result.stderr)
-            success = any('normal termination' in line.lower() for line in output_lines)
-            print("je suis jackie",output_lines)
-        except sp.CalledProcessError as e:
-            output_lines = e.stdout.splitlines() if e.stdout else []
-            print(f"Model failed: {e.returncode}\n{e.stderr}")
-            success = False
+        output_lines = []
+        success = False
+        normal_msg = "Fin normale du calcul"
+
+        # ---- Run the model
+        if silent:
+            # Blocking mode
+            try:
+                result = sp.run([exe, rma_file], capture_output=True, text=True, check=False)
+                output_lines = result.stdout.splitlines()
+                success = any(normal_msg.lower() in line.lower() for line in output_lines)
+                if result.returncode != 0 and not success:
+                    print(f"[Erreur] Le modèle s’est terminé avec le code {result.returncode}")
+            except Exception as e:
+                print(f"[Erreur] L’exécution a échoué : {e}")
+                success = False
+
+        else:
+            # Live stdout mode
+            try:
+                with sp.Popen([exe, rma_file], stdout=sp.PIPE, stderr=sp.STDOUT, text=True, bufsize=1) as proc:
+                    for line in proc.stdout:
+                        line = line.rstrip()
+                        output_lines.append(line)
+                        print(line)
+                        if normal_msg.lower() in line.lower():
+                            success = True
+
+                    proc.wait()
+                    if proc.returncode != 0 and not success:
+                        print(f"[Erreur] Le modèle s’est terminé avec le code {proc.returncode}")
+                        success = False
+
+            except Exception as e:
+                print(f"[Erreur] Impossible d’exécuter le modèle : {e}")
+                success = False
 
         return success, output_lines
-        # # TODO sma Popen blocks
-        # else:
-        #     # ---- Run the model with real-time output
-        #     try:
-        #         with sp.Popen([exe, rma_file], stdout=sp.PIPE, stderr=sp.STDOUT, text=True) as proc:
-        #             for line in proc.stdout:
-        #                 line = line.rstrip()
-        #                 output_lines.append(line)
-        #                 print(line)
-        #                 if normal_msg in line.lower():
-        #                     success = True
-        #             proc.wait()
-        #             if proc.returncode != 0 and not success:
-        #                 print(f"Model exited with return code {proc.returncode}")
-        #                 success = False
-        #     except Exception as e:
-        #         print(f"Failed to run model: {e}")
-        #         success = False
-
 
         # TODO keeping the olds Popen blocks whenever it's needed
         # it decided to go back with

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -1624,12 +1624,12 @@ class MartheModel():
         """
         Private function for checking spatial index files. Intent to capture a
         FileNotFoundError if index files are not found. While rtree.index.Index will
-        not return an Error, it creates an empty index.Index instead.
+        not return an Error but creates an empty index.Index instead.
 
         Parameters
         ----------
         spatial_index : str
-            The path to the spatial index prefix file (without extension).
+            The relative or absolute path to the spatial index prefix file (without extension).
 
         Raises
         ------

--- a/pymarthe/marthe.py
+++ b/pymarthe/marthe.py
@@ -482,6 +482,8 @@ class MartheModel():
         # ---- Load permh field
         imask = MartheField('imask', self.mlfiles['permh'], self)
         # ---- Change data to binary
+        # Replace 9999 values by 0
+        imask.data['value'][imask.data['value'] == 9999] = 0
         imask.data['value'] = (imask.data['value'] != 0).astype(int)
         # ---- Return MartheField instance
         return imask
@@ -604,6 +606,7 @@ class MartheModel():
         # -- Build MartheModel from configuration file
         hdic, pdics, _ = pest_utils.read_config(configfile)
         si = None if hdic['Model spatial index'] == 'None' else hdic['Model spatial index']
+        print(hdic)
         mm = cls(hdic['Model full path'], spatial_index=si)
 
         # -- Iterate over parameter dictionaries

--- a/pymarthe/mfield.py
+++ b/pymarthe/mfield.py
@@ -254,10 +254,6 @@ class MartheField():
         else:
             return self.data[mask]
 
-
-
-
-
     def set_data(self, data, layer=None, inest=None):
         """
         Set field data for active cells (where imask is 1) and NON-masked values (see dmv)
@@ -288,6 +284,11 @@ class MartheField():
         mf.set_data(2.3e-3, layer=2, inest=3) # one nest
 
         """
+        # ---- Checks if layer in mm.nlay
+        if layer is not None and layer not in range(self.mm.nlay):
+            raise ValueError(f"layer {layer} does not exist, "
+                             f"choose one from layer 0 to layer {self.mm.nlay-1}")
+
         # ---- Set all useful conditions
         _none = all(x is None for x in [layer, inest])
         _str = isinstance(data, str)
@@ -327,14 +328,18 @@ class MartheField():
         if _rec:
             self.data = self.get_masked(data)
 
-        # ---- Manage 3D-array input
-        if np.logical_and.reduce([_arr, not _rec, _none]):
-            # -- Verify data is a 3D-array
-            err_msg = f"ERROR: `data` array must be 3D. Given shape: {data.shape}."
-            assert len(data.shape) == 3, err_msg
-            self.data = self.get_masked(self._3d2rec(data))
+        # ---- Manage 2D-3D-array input
+        if _arr:
 
+            err_msg = (f"ERROR: `data` array must be 2D with a layer argmuent or"
+                       f"3D with layer=None. Given shape: {len(data.shape)}, given layer = {layer}.")
 
+            if len(data.shape) == 3 and layer is None:
+                self.data = self.get_masked(self._3d2rec(data))
+            elif len(data.shape) == 2 and layer is not None:
+                self.data = self.get_masked(self._2d2rec(data,layer))
+            else:
+                raise ValueError(err_msg)
 
     def get_masked(self, rec):
         """
@@ -478,13 +483,11 @@ class MartheField():
         # ---- Stack all recarrays as once
         return rec
 
-
-
     def _3d2rec(self, arr3d):
         """
         Convert 3D-array
         Wrapper of marthe_utils.read_grid_file().
-
+        Note sma : docstring looks deprecated, it should be rewrite
         Parameters:
         ----------
         filename (str) : path to Marthe field property file.
@@ -498,22 +501,21 @@ class MartheField():
         Examples:
         --------
         rec = mf._grid2rec('mymodel.emmca')
-        
+
         """
+        # TODO : may be remove ? Actualy this check is late,
+        # TODO : we may check the mm instance in the MartheField class __init__()
+        # TODO : Will be fixed with a minor commit
         # ---- Assert MartheModel exist
         err_msg = "ERROR: Building a `MartheField` instance from a 3D-array " \
                   "require a referenced `MartheModel` instance. " \
                   "Try MartheField(field, data, mm = MartheModel('mymodel.rma'))."
-        assert self.mm.__str__() == 'MartheModel' , err_msg
-
-        # ---- Assert array is 3D
-        err_msg = f"ERROR: `data` must be a 3D-array. Given shape: {arr3d.shape}"
-        assert len(arr3d.shape) == 3, err_msg
+        assert self.mm.__str__() == 'MartheModel', err_msg
 
         # ---- Fetch basic model structure
         rec = deepcopy(self.mm.imask.data)
         df = pd.DataFrame.from_records(rec)
-        
+
         # ---- Modify rec inplace
         for layer, arr2d in enumerate(arr3d):
             mask = (df.layer == layer) & (df.inest == 0)
@@ -522,8 +524,36 @@ class MartheField():
         # ---- Return recarray
         return df.to_records(index=False)
 
+    def _2d2rec(self, arr, layer=None):
+        """
+        Convert 2D-array to rec array. This method is called by the
+        MartheField.set_data method and should not be called directly.
 
+        Parameters:
+        ----------
+        arr (np.ndarray) : A 2D numpy ndarray.
 
+        Returns:
+        --------
+        rec (np.recarray) : recarray with all usefull informations
+                            for each model grid cell such as layer,
+                            inest, value, ...
+        """
+        # ---- Assert MartheModel exist
+        err_msg = "ERROR: Building a `MartheField` instance from a 3D-array " \
+                  "require a referenced `MartheModel` instance. " \
+                  "Try MartheField(field, data, mm = MartheModel('mymodel.rma'))."
+        assert self.mm.__str__() == 'MartheModel', err_msg
+
+        # ---- Fetch basic model structure
+        rec = deepcopy(self.mm.imask.data)
+        df = pd.DataFrame.from_records(rec)
+
+        mask = (df.layer == layer) & (df.inest == 0)
+        df.loc[mask, 'value'] = arr.ravel()
+
+        # ---- Return recarray
+        return df.to_records(index=False)
 
     def _rec2grid(self, layer, inest):
         """

--- a/pymarthe/mfield.py
+++ b/pymarthe/mfield.py
@@ -61,8 +61,14 @@ class MartheField():
         -----------
         mm.mobs.compute_weights(lambda_dic)
         """
-        self.field = field
+        # ----Check for mm type, avoid futures checks and uncaptured errors
+        from .marthe import MartheModel
+        if not isinstance(mm, MartheModel):
+            raise TypeError(f"mm must be a MartheModel, not a {type(mm).__name__}")
+
+        # ---- Set attributes
         self.mm = mm
+        self.field = field
         self.dmv = dmv
         self.use_imask = use_imask
         self.set_data(data)
@@ -337,7 +343,7 @@ class MartheField():
             if len(data.shape) == 3 and layer is None:
                 self.data = self.get_masked(self._3d2rec(data))
             elif len(data.shape) == 2 and layer is not None:
-                self.data = self.get_masked(self._2d2rec(data,layer))
+                self.data = self.get_masked(self._2d2rec(data, layer))
             else:
                 raise ValueError(err_msg)
 
@@ -503,15 +509,6 @@ class MartheField():
         rec = mf._grid2rec('mymodel.emmca')
 
         """
-        # TODO : may be remove ? Actualy this check is late,
-        # TODO : we may check the mm instance in the MartheField class __init__()
-        # TODO : Will be fixed with a minor commit
-        # ---- Assert MartheModel exist
-        err_msg = "ERROR: Building a `MartheField` instance from a 3D-array " \
-                  "require a referenced `MartheModel` instance. " \
-                  "Try MartheField(field, data, mm = MartheModel('mymodel.rma'))."
-        assert self.mm.__str__() == 'MartheModel', err_msg
-
         # ---- Fetch basic model structure
         rec = deepcopy(self.mm.imask.data)
         df = pd.DataFrame.from_records(rec)
@@ -539,16 +536,9 @@ class MartheField():
                             for each model grid cell such as layer,
                             inest, value, ...
         """
-        # ---- Assert MartheModel exist
-        err_msg = "ERROR: Building a `MartheField` instance from a 3D-array " \
-                  "require a referenced `MartheModel` instance. " \
-                  "Try MartheField(field, data, mm = MartheModel('mymodel.rma'))."
-        assert self.mm.__str__() == 'MartheModel', err_msg
-
         # ---- Fetch basic model structure
         rec = deepcopy(self.mm.imask.data)
         df = pd.DataFrame.from_records(rec)
-
         mask = (df.layer == layer) & (df.inest == 0)
         df.loc[mask, 'value'] = arr.ravel()
 

--- a/pymarthe/moptim.py
+++ b/pymarthe/moptim.py
@@ -6,7 +6,7 @@ Designed for structured grid
 
 import os, sys
 import numpy as np
-import pandas as pd 
+import pandas as pd
 import pyemu
 import warnings
 from datetime import datetime
@@ -30,7 +30,7 @@ base_param = ['parnme', 'trans', 'btrans', 'parchglim',
               'pargp', 'scale', 'offset', 'dercom']
 
 
-# ---- Set encoding 
+# ---- Set encoding
 encoding = 'latin-1'
 
 
@@ -112,7 +112,7 @@ class MartheOptim():
 
 
 
-
+    # TODO : get_param_df also a method of MartheGridParam class. Maybe be confusive..
     def get_param_df(self, transformed=False):
         """
         Get all parameters informations in a large DataFrame.
@@ -267,7 +267,7 @@ class MartheOptim():
             return exi, uni
         # ---- Empty return for inactive check
         elif error == 'off':
-            return 
+            return
 
 
 
@@ -346,7 +346,7 @@ class MartheOptim():
             assert ('value' in data.columns), err_msg
             # -- Get locnme if not provided
             locnme = f'loc{str(self.get_nlocs()).zfill(3)}' if locnme is None else locnme
-        
+
         # ---- Avoid adding same locnme multiple times
         if locnme in self.obs.keys():
             # -- Raise warning message
@@ -378,7 +378,7 @@ class MartheOptim():
                                f'are out of actual model time window ({self.tw_min} - {self.tw_max}). ' \
                                'They will not be considered.'
                     warnings.warn(warn_msg)
-        except : # no date format 
+        except : # no date format
             df_tw = df
 
         # ---- Build MartheObs instance from data input
@@ -598,7 +598,7 @@ class MartheOptim():
         for ln in locnmes:
             self.obs[ln].write_insfile()
 
-            
+
 
     def write_simfile(self, locnme=None, prnfile=None):
         """
@@ -702,7 +702,7 @@ class MartheOptim():
                 new_dt = self.obs[ln].datatype + tag + 'f'
                 self.add_obs(data = df, locnme = new_locnme,
                              datatype = new_dt, check_loc = False,
-                             fluc_dic = {'tag':tag,'on':on}, 
+                             fluc_dic = {'tag':tag,'on':on},
                             **kwargs)
             else:
                 warn_msg = f"WARNING : could not found observation with `locnme` = {ln}. " \
@@ -764,10 +764,6 @@ class MartheOptim():
                 self.obs[locnme].weight = w
                 self.obs[locnme].obs_df['weight'] = w
 
-
-
-
-
     def add_param(self, parname, mobj, **kwargs):
         """
         Add a parameter a set of parameters.
@@ -803,7 +799,7 @@ class MartheOptim():
         Examples
         -----------
         # -- Example on pumping data
-        mm.load_prop('soil')
+        mm.load_prop('aqpump')
         mp = mm.prop['aqpump']
         kmi_p31 = pest_utils.get_kmi(mp, keys = ['boundname', 'layer', 'istep'], boundname = 'p31')
         mgp.add_param(parname='p31', mobj=mp,
@@ -1173,7 +1169,7 @@ class MartheOptim():
                                exe_name= 'Marth_R8')
 
         """
-        
+
         with open(fr_file, 'w', encoding='utf-8') as f:
 
             # ---- Print artistic header
@@ -1224,7 +1220,7 @@ class MartheOptim():
                 for i, func in enumerate(ext_func):
                     # -- Assert that item is a function
                     err_msg = 'ERROR : All single items in `extra_functions` must be callable. ' \
-                              f'Given : {type(func)}' 
+                              f'Given : {type(func)}'
                     assert callable(func), err_msg
                     f.write(f"# -- Extra function n°{i+1}\n")
                     # -- Get source code of the function
@@ -1242,7 +1238,7 @@ class MartheOptim():
             # -- Perform a forward run from .config file
             f.write('\t# -- Run model from .config file\n')
             run_lines = ['\tpymarthe.utils.pest_utils.run_from_config(',
-                        f'"{configfile}"',
+                        f'r"{configfile}"',
                         *[f', {k}={v}' if isinstance(v,(type(None), bool)) else f', {k}="{v}"' for k,v in kwargs.items()],
                         ')\n']
             f.write(''.join(run_lines))

--- a/pymarthe/mparam.py
+++ b/pymarthe/mparam.py
@@ -997,7 +997,10 @@ class MartheGridParam():
         vgmr = {}
         if np.isscalar(vgm_range):
             # -- Same range for all variograms (layers and zones)
-            vgmr = {k: {zone: vgm_range} for k,v in self.pp_dic.items() for zone in v.zone.unique()}
+            vgmr = {
+                k: {zone: vgm_range for zone in v.zone.unique()}
+                for k, v in self.pp_dic.items()
+            }
         elif isinstance(vgm_range, dict):
             # -- Verify layer keys matching between pilot point and variogram dictionaries
             err_msg =  "ERROR : `vgm_range` must have same layer keys as pilot point " 

--- a/pymarthe/mparam.py
+++ b/pymarthe/mparam.py
@@ -1051,7 +1051,7 @@ class MartheGridParam():
                     cov.to_coo(kfac_file.replace('.fac', '.jcb')) # Format = `coo` to avoid 12 char length limit
 
 
-
+    # TODO : get_param_df also a method of MartheOptim class. Maybe be confusive..
     def get_param_df(self, transformed=False):
         """
         Join all parameter informations in a single DataFrame

--- a/pymarthe/mpump.py
+++ b/pymarthe/mpump.py
@@ -225,11 +225,11 @@ class MarthePump():
 
         # ---- Build query (format: q = 'column_0 in [value_0,..] & ...'')
         q = ' & '.join(
-            ["{} in {}".format(k, list(self.data[k].unique()))
-             if v is None else "{} in {}".format(k, list(marthe_utils.make_iterable(v)))
-             for k, v
-             in zip(col_query, [istep, node, layer, i, j, boundname])
-             ]
+            [
+                "{} in {}".format(k, self.data[k].unique().tolist()) if v is None
+                else "{} in {}".format(k, list(marthe_utils.make_iterable(v)))
+                for k, v in zip(col_query, [istep, node, layer, i, j, boundname])
+            ]
         )
 
         # ---- Force all provided isteps (slow)

--- a/pymarthe/mpump.py
+++ b/pymarthe/mpump.py
@@ -12,13 +12,14 @@ import warnings
 
 encoding = 'latin-1'
 
+
 class MarthePump():
     """
     Class for handling Marthe pumping data.
 
     """
 
-    def __init__(self, mm, pastp_file = None,  mode = 'aquifer', verbose=False):
+    def __init__(self, mm, pastp_file=None, mode='aquifer', verbose=False):
         """
         MarthePump class : available for aquifer or river pumping.
 
@@ -60,10 +61,6 @@ class MarthePump():
         if verbose:
             self._verbose()
 
-
-
-
-
     def _verbose(self):
         """
         Perform some classic checks about pumping data validity and print
@@ -78,37 +75,32 @@ class MarthePump():
             for node in self.data['node']:
                 if self.mm.imask.data['value'][node] == 0:
                     coords = 'Node = {}, Layer = {}, Nested = {}, Row = {}, Column = {} .'.format(
-                                    node,
-                                    self.mm.imask.data['layer'][node],
-                                    self.mm.imask.data['inest'][node],
-                                    self.mm.imask.data['i'][node],
-                                    self.mm.imask.data['j'][node]
-                                )
+                        node,
+                        self.mm.imask.data['layer'][node],
+                        self.mm.imask.data['inest'][node],
+                        self.mm.imask.data['i'][node],
+                        self.mm.imask.data['j'][node]
+                    )
                     warnings.warn(warn_msg + coords)
         except:
             pass
 
-
-
         # -- Search for several pumping data on same node
         warn_msg = "Multiple pumping condition in same cell : "
         try:
-            agg = self.data.groupby(['istep','node'], as_index=False).size()
+            agg = self.data.groupby(['istep', 'node'], as_index=False).size()
             nodes = agg.loc[agg['size'] > 1, 'node'].unique()
             for node in nodes:
                 coords = 'Node = {}, Layer = {}, Nested = {}, Row = {}, Column = {} .'.format(
-                                node,
-                                self.mm.imask.data['layer'][node],
-                                self.mm.imask.data['inest'][node],
-                                self.mm.imask.data['i'][node],
-                                self.mm.imask.data['j'][node]
-                            )
+                    node,
+                    self.mm.imask.data['layer'][node],
+                    self.mm.imask.data['inest'][node],
+                    self.mm.imask.data['i'][node],
+                    self.mm.imask.data['j'][node]
+                )
                 warnings.warn(warn_msg + coords)
         except:
             pass
-
-
-
 
     def _extract_data(self, mode):
         """
@@ -129,7 +121,7 @@ class MarthePump():
         mp._extract_data()
 
         """
-        
+
         # ---- Manage 'aqpump'
         if self.mode == 'aquifer':
             d, _d = marthe_utils.extract_pastp_pumping(self.pastp_file, mode)
@@ -137,20 +129,36 @@ class MarthePump():
         # ---- Manage 'rivpump'
         elif self.mode == 'river':
             # ---- Convert aff/trc data in column, line, plan (layer) format in .pastp file
-            marthe_utils.convert_at2clp(self.pastp_file, mm = self.mm)
+            marthe_utils.convert_at2clp(self.pastp_file, mm=self.mm)
             d, _d = marthe_utils.extract_pastp_pumping(self.pastp_file, mode)
 
         # -- Manage xy inputs
-        if all(loc in d.columns for loc in list('xy')):
-            # -- Print message to inform about convertion
+        if all(loc in d.columns for loc in ['x', 'y']):
             print('Converting xy pumping data into row(s), column(s) ...')
-            # -- Get all nodes
-            nodes = self.mm.get_node(x=_d.x,y=_d.y,layer=_d.layer)
-            # -- Perform query on modlegrid
-            _d[['node','i','j']] = self.mm.query_grid(node=nodes, target=['i','j']).reset_index()
-            # -- Push to class attribute
-            self.data, self._data = _d[self.vars], _d[self._vars + ['x','y']]
+            # -- In case that col x and y have nan values
+            if _d['x'].isna().any() or _d['y'].isna().any():
+                # -- Keep only rows with valid x and y
+                _d_clean = _d.dropna(subset=['x', 'y'])
 
+                # -- Get nodes and query model grid
+                nodes = self.mm.get_node(x=_d_clean['x'], y=_d_clean['y'], layer=_d_clean['layer'])
+                grid_info = self.mm.query_grid(node=nodes, target=['i', 'j']).reset_index()
+
+                # -- Update _d_clean with grid info
+                _d_clean = _d_clean.reset_index(drop=False)
+                _d_clean[['node', 'i', 'j']] = grid_info
+                _d_clean.set_index('index', inplace=True)
+
+                # -- Update original DataFrame with computed data
+                _d.loc[_d_clean.index, ['node', 'i', 'j']] = _d_clean[['node', 'i', 'j']]
+            else:
+                # -- All rows are valid: process directly
+                nodes = self.mm.get_node(x=_d['x'], y=_d['y'], layer=_d['layer'])
+                _d[['node', 'i', 'j']] = self.mm.query_grid(node=nodes, target=['i', 'j']).reset_index()
+            # -- Push final data to class attributes
+            self.data = _d[self.vars]
+            self._data = _d[self._vars + ['x', 'y']]
+            print(self.data, self._data)
         # -- Manage ij inputs
         else:
             # -- Perform query on modelgrid
@@ -158,21 +166,16 @@ class MarthePump():
             # -- Push to class attribute
             self.data, self._data = _d[self.vars], _d[self._vars]
 
-
         # ---- Set generic boundnames
         digits = len(str(self.data.node.max()))
-        bdnmes =  ['{}_{}'.format(
-                        self.prop_name,
-                        str(node).zfill(digits)
-                        )
-                    for node in self.data.node]
-        self.data['boundname'], self._data['boundname'] = [bdnmes]*2
+        bdnmes = ['{}_{}'.format(
+            self.prop_name,
+            str(node).zfill(digits)
+        )
+            for node in self.data.node]
+        self.data['boundname'], self._data['boundname'] = [bdnmes] * 2
 
-
-
-
-
-    def get_data(self, istep=None, node=None, layer=None, i=None, j=None, boundname=None, force=False , as_mask=False):
+    def get_data(self, istep=None, node=None, layer=None, i=None, j=None, boundname=None, force=False, as_mask=False):
         """
         Function to select/subset pumping data.
 
@@ -222,13 +225,13 @@ class MarthePump():
 
         # ---- Build query (format: q = 'column_0 in [value_0,..] & ...'')
         q = ' & '.join(
-                ["{} in {}".format(k, list(self.data[k].unique())) 
-                    if v is None else "{} in {}".format(k, list(marthe_utils.make_iterable(v)))
-                    for k, v 
-                    in zip(col_query, [istep,node,layer,i,j,boundname])
-                    ]
-                        )
-        
+            ["{} in {}".format(k, list(self.data[k].unique()))
+             if v is None else "{} in {}".format(k, list(marthe_utils.make_iterable(v)))
+             for k, v
+             in zip(col_query, [istep, node, layer, i, j, boundname])
+             ]
+        )
+
         # ---- Force all provided isteps (slow)
         if force:
             # -- Subset (without timestep)
@@ -238,7 +241,7 @@ class MarthePump():
                 df = df_ss.loc[df_ss.istep == istep]
                 # -- If istep not provided in pastp file
                 if df.empty:
-                    nip = df_ss.loc[df_ss.istep < istep, 'istep'].max()   # nip = nearest previous istep
+                    nip = df_ss.loc[df_ss.istep < istep, 'istep'].max()  # nip = nearest previous istep
                     np_df = df_ss[df_ss.istep == nip]
                     np_df['istep'] = istep
                     dfs.append(np_df)
@@ -268,11 +271,6 @@ class MarthePump():
         else:
             return df
 
-
-
-
-
-
     def set_data_from_parfile(self, parfile, keys, value_col, btrans):
         """
         """
@@ -281,7 +279,7 @@ class MarthePump():
         # -- Get kmi and transformed values
         kmi, bvalues = pest_utils.parse_mlp_parfile(parfile, keys, value_col, btrans)
         # find intersection of keys with parameter data columns
-        for k in kmi.names :
+        for k in kmi.names:
             if k not in df.columns:
                 kmi = kmi.droplevel(k)
         # -- Convert to MultiIndex Dataframe
@@ -291,9 +289,6 @@ class MarthePump():
         data = mi_df.reset_index()
         # -- Set data inplace
         self.data, self._data = data[self.vars], data[self._vars]
-
-
-
 
     def set_data(self, value, istep=None, node=None, layer=None, i=None, j=None, boundname=None):
         """
@@ -340,9 +335,6 @@ class MarthePump():
         # ---- Replace previous data
         self._data, self.data = df[self._vars], df[self.vars]
 
-
-
-
     def get_boundnames(self, istep=None, layer=None, i=None, j=None):
         """
         Function to get boundname on subset data.
@@ -380,8 +372,6 @@ class MarthePump():
         # ---- Return boundnames as list of string
         return boundnames
 
-
-
     def switch_boundnames(self, switch_dic):
         """
         Function to change boundname of a pumping point by another.
@@ -405,9 +395,6 @@ class MarthePump():
         self._data['boundname'] = self._data['boundname'].replace(switch_dic)
         # self.data['boundname'].replace(switch_dic, inplace=True)
         self.data['boundname'] = self.data['boundname'].replace(switch_dic)
-
-
-
 
     def split_qtype(self, qtype=None):
         """
@@ -444,17 +431,13 @@ class MarthePump():
         gb = self._data.groupby('qtype')
 
         # ---- Split data by qtype
-        dfs = [gb.get_group(qt) 
+        dfs = [gb.get_group(qt)
                if qt in self._data['qtype'].unique()
-               else pd.DataFrame() 
+               else pd.DataFrame()
                for qt in qtypes]
 
         # ---- Return list of (required) DataFrames
         return dfs
-
-
-
-
 
     def _write_mail(self):
         """
@@ -504,11 +487,11 @@ class MarthePump():
                 df = mail_df.loc[mail_df['istep'] == istep]
                 # ---- Update replace dictionary for this istep
                 repl_dic = {}
-                for i,row in df.iterrows():
-                    c,l,p,v = row[['j','i','layer','value']].astype(str)
-                    match = r''.join(['C=', sp, c, 'L=', sp, l, 
-                                     'P=', sp, p, 'V=', sp, re_num])
-                    repl = 'C={:>7}L={:>7}P={:>7}V={:>10}'.format(c,l,p,v)
+                for i, row in df.iterrows():
+                    c, l, p, v = row[['j', 'i', 'layer', 'value']].astype(str)
+                    match = r''.join(['C=', sp, c, 'L=', sp, l,
+                                      'P=', sp, p, 'V=', sp, re_num])
+                    repl = 'C={:>7}L={:>7}P={:>7}V={:>10}'.format(c, l, p, v)
                     repl_dic[match] = repl
                 # ---- stock as new line
                 new_lines.append(line)
@@ -528,8 +511,6 @@ class MarthePump():
         # ---- Write all data
         with open(self.pastp_file, 'w') as f:
             f.write(''.join(new_lines))
-
-
 
     def _write_record(self):
         """
@@ -559,7 +540,7 @@ class MarthePump():
         # ---- Set usefull regex
         re_block = r";\s*\*{3}\s*\n(.*?)/\*{5}"
         re_num = r"[-+]?\d*\.?\d+|\d+"
-        re_jikv = r"C=\s*({})L=\s*({})P=\s*({})V=\s*({});".format(*[re_num]*4)
+        re_jikv = r"C=\s*({})L=\s*({})P=\s*({})V=\s*({});".format(*[re_num] * 4)
 
         # ---- Define mode tag
         mode_tag = '/DEBIT/' if self.mode == 'aquifer' else '/Q_EXTER_RIVI/'
@@ -571,7 +552,7 @@ class MarthePump():
         for line in steady_block.splitlines(True):
             if all(s in line for s in [mode_tag + 'MAIL', 'File=']):
                 # ---- Fetch localisation infos
-                c,l,p,v = map(ast.literal_eval, re.findall(re_jikv, line)[0])
+                c, l, p, v = map(ast.literal_eval, re.findall(re_jikv, line)[0])
                 # ---- Query record DataFrame
                 q = f'i == {l} & j == {c} & layer == {p} & istep == 0'
                 new_v = rec_df.query(q)['value'].values[0]
@@ -585,17 +566,14 @@ class MarthePump():
         # ---- Rewrite transient data in external file       
         for qfilename in rec_df['qfilename'].unique():
             # ---- Read external file 
-            df = pd.read_csv(qfilename,  delim_whitespace=True)
+            df = pd.read_csv(qfilename, delim_whitespace=True)
             # ---- Set new values
             rec_df_ss = rec_df.query(f"istep != 0 & qfilename == '{qfilename}'")
             for qcol, gb in rec_df_ss.groupby('qcol'):
-                df.iloc[:,int(qcol)] = gb['value'].values
+                df.iloc[:, int(qcol)] = gb['value'].values
             # ---- Rewrite external file
             # NOTE should be updated with to_string()
-            df.to_csv(qfilename, sep = '\t',header = True,index = False)
-
-
-
+            df.to_csv(qfilename, sep='\t', header=True, index=False)
 
     def _write_listm(self):
         """
@@ -622,25 +600,23 @@ class MarthePump():
         listm_df[['layer', 'i', 'j']] = listm_df[['layer', 'i', 'j']].add(1)
 
         # ---- Write (modified) data
-        for (istep, qfilename), data in listm_df.groupby(['istep','qfilename']):
+        for (istep, qfilename), data in listm_df.groupby(['istep', 'qfilename']):
             df = pd.read_csv(qfilename, header=None, delim_whitespace=True)
             for qcol, gb in data.groupby('qcol'):
-                df.iloc[:,int(qcol)] = gb['value'].values
+                df.iloc[:, int(qcol)] = gb['value'].values
             #df.to_csv(qfilename, sep='\t', header=False, index=False)
             # format definition flexible to handle both "x, y, value" and "value, ligne, colonne, plan"
             # fixed-width format (check widths !)
             FFMT = lambda x: "{0:>20.10E} ".format(float(x))
             IFMT = lambda x: "{0:>6d} ".format(int(x))
-            fmt_dic = {'i':IFMT,'f':FFMT} 
-            formatters = [ fmt_dic[df[c].dtype.kind] for c in df]
+            fmt_dic = {'i': IFMT, 'f': FFMT}
+            formatters = [fmt_dic[df[c].dtype.kind] for c in df]
             with open(qfilename, 'w', encoding=encoding) as f:
-                    f.write(df.to_string( col_space=0,
-                                          formatters=formatters,
-                                         justify="left", header=False, index=False, 
-                                         index_names=False, 
-                                         max_rows = len(df), min_rows = len(df) ) )
-
-
+                f.write(df.to_string(col_space=0,
+                                     formatters=formatters,
+                                     justify="left", header=False, index=False,
+                                     index_names=False,
+                                     max_rows=len(df), min_rows=len(df)))
 
     def write_data(self):
         """
@@ -676,7 +652,6 @@ class MarthePump():
         # ---- Write multiple cell / single condition (listm)
         if not listm_df.empty:
             self._write_listm()
-
 
     def __str__(self):
         """

--- a/pymarthe/utils/marthe_utils.py
+++ b/pymarthe/utils/marthe_utils.py
@@ -15,11 +15,8 @@ from .grid_utils import MartheGrid
 # Set encoding
 encoding = 'latin-1'
 
-
 # Set commun no data values
 NO_DATA_VALUES = [-9999., -8888.]
-
-
 
 
 def deprecated(func):
@@ -29,6 +26,7 @@ def deprecated(func):
     when the function is used. Addtionnal message 'use funcname
     instead.' is written if provided.
     """
+
     # -- Build decorator
     @functools.wraps(func)
     def new_func(*args, **kwargs):
@@ -38,13 +36,11 @@ def deprecated(func):
         msg = "Function `.{}`() is now deprecated. ".format(func.__name__)
         # -- Write deprecation warning
         warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
-          # -- Reset filter
+        # -- Reset filter
         warnings.simplefilter('default', DeprecationWarning)
         return func(*args, **kwargs)
+
     return new_func
-
-
-
 
 
 def unanimous(obj):
@@ -65,7 +61,6 @@ def unanimous(obj):
     res = True if len(set(map(len, seq))) == 1 else False
     # -- Return boolean
     return res
-
 
 
 def get_mlfiles(rma_file):
@@ -94,14 +89,13 @@ def get_mlfiles(rma_file):
     # ---- Fetch all marthe file paths
     re_mlfile = r"\n(.+?)="
     mlfiles = [s.strip() for s in re.findall(re_mlfile, content)
-                         if (not s.isspace()) & ('=' not in s)]
+               if (not s.isspace()) & ('=' not in s)]
 
     # ---- Build dictionary with all marthe file path
-    mlfiles_dic = {mlfile.split('.')[-1]: 
-                        os.path.normpath(
-                            os.path.join(mldir, mlfile)) for mlfile in mlfiles}
+    mlfiles_dic = {mlfile.split('.')[-1]:
+        os.path.normpath(
+            os.path.join(mldir, mlfile)) for mlfile in mlfiles}
     return mlfiles_dic
-
 
 
 def progress_bar(percent, barlen=50):
@@ -129,15 +123,14 @@ def progress_bar(percent, barlen=50):
         progress_bar(percent, berlen=70)
 
     """
-    
+
     # ---- Write graphical percent according to barlen
     sys.stdout.write('\r')
-    sys.stdout.write(f"[{'='*int(barlen * percent):{barlen}s}] {int(100*percent)}%")
+    sys.stdout.write(f"[{'=' * int(barlen * percent):{barlen}s}] {int(100 * percent)}%")
     sys.stdout.flush()
 
 
-
-def get_layers_infos(layfile, base = 1):
+def get_layers_infos(layfile, base=1):
     """
     -----------
     Description:
@@ -177,16 +170,16 @@ def get_layers_infos(layfile, base = 1):
              r"[Epon|Épon] Sup =\s*(\d+)", r"Ke=\s*(\d+)", r"Anisot=\s*(\d+)"]
     # ---- Build Dataframe of all layer informations
     df = pd.DataFrame([re.findall(r, content) for r in regex],
-                      index =['layer', 'thickness', 'epon_sup', 'ke', 'anisotropy'],
+                      index=['layer', 'thickness', 'epon_sup', 'ke', 'anisotropy'],
                       dtype=float).T
     # ---- Manage dtypes of informations
     dtypes = [int, float, int, float, float]
-    layers_infos = df.astype({col:dt for col, dt in zip(df.columns, dtypes)})
+    layers_infos = df.astype({col: dt for col, dt in zip(df.columns, dtypes)})
     # ---- Manage layer counting from base
-    layers_infos['layer'] = layers_infos['layer'].add(base-1)
+    layers_infos['layer'] = layers_infos['layer'].add(base - 1)
 
     # ---- Add layer name if exist
-    re_lnmes =  r";\s*Name=\s*(.+)\n"
+    re_lnmes = r";\s*Name=\s*(.+)\n"
     if re.search(re_lnmes, content) is None:
         layers_infos['name'] = 'layer_' + layers_infos['layer'].astype(str)
     else:
@@ -196,7 +189,6 @@ def get_layers_infos(layfile, base = 1):
     nnest = int(re.findall(r"(\d+)=Nombre", content)[0])
     # ---- Return infos
     return nnest, layers_infos
-
 
 
 def has_soilprop(text):
@@ -224,7 +216,6 @@ def has_soilprop(text):
     """
     res = True if '/ZONE_SOL' in text else False
     return res
-
 
 
 def extract_soildf(text, istep=None):
@@ -264,24 +255,21 @@ def extract_soildf(text, istep=None):
     re_num = r"[-+]?\d*\.?\d+|\d+"
     re_prop = r"\s*\/(.+)\/ZONE_SOL\s*Z=\s*({0})V=\s*(.+);".format(re_num)
     # -- Define data type
-    dt_dic = {c:dt for c,dt
-               in zip(['soilprop', 'zone', 'value'],
-                      [str, int, float])}
+    dt_dic = {c: dt for c, dt
+              in zip(['soilprop', 'zone', 'value'],
+                     [str, int, float])}
     # -- Extract soil data with regex (line-by-line)
     data = re.findall(re_prop, text)
     # -- Build soil DataFrame with correct data types
     soil_df = pd.DataFrame(data, columns=dt_dic.keys()).astype(dt_dic)
     # -- Sort by lower case soil properties names
-    soil_df['soilprop'] =  soil_df['soilprop'].str.lower()
+    soil_df['soilprop'] = soil_df['soilprop'].str.lower()
     soil_df = soil_df.sort_values('soilprop').reset_index(drop=True)
     # -- Add istep column if required
     if not istep is None:
         soil_df.insert(0, 'istep', istep)
     # -- Return soil properties DataFrame
     return soil_df
-
-
-
 
 
 def read_zonsoil_prop(martfile, pastpfile):
@@ -323,7 +311,7 @@ def read_zonsoil_prop(martfile, pastpfile):
 
     """
     # -- Check if martfile contains soil property(ies)
-    with open(martfile, 'r',encoding=encoding) as f:
+    with open(martfile, 'r', encoding=encoding) as f:
         mart_content = f.read()
     _mart = True if has_soilprop(mart_content) else False
 
@@ -337,8 +325,8 @@ def read_zonsoil_prop(martfile, pastpfile):
                f"in both {martfile} and {pastpfile} files."
     err_none = "ERROR : No soil properties found " \
                f"in both {martfile} and {pastpfile} files."
-    assert any(x is False for x in [_mart,_pastp]), err_both
-    assert any(x is True  for x in [_mart,_pastp]), err_none
+    assert any(x is False for x in [_mart, _pastp]), err_both
+    assert any(x is True for x in [_mart, _pastp]), err_none
 
     # -- Manage constante soil properties store in .mart file
     if _mart:
@@ -358,7 +346,7 @@ def read_zonsoil_prop(martfile, pastpfile):
         # -- Set soil properties mode
         mode = 'pastp-t' if counter > 1 else 'pastp-c'
         # -- Extract soil DataFrame for each time step if provided
-        soil_dfs = [extract_soildf(block, istep) 
+        soil_dfs = [extract_soildf(block, istep)
                     for istep, block in enumerate(blocks)
                     if has_soilprop(block)]
         # -- Concatenate all time step DataFrame
@@ -366,8 +354,6 @@ def read_zonsoil_prop(martfile, pastpfile):
 
     # -- Return implementation mode and soil properties DataFrame
     return mode, soil_df
-
-
 
 
 def remove_autocal(rmafile, martfile):
@@ -403,7 +389,7 @@ def remove_autocal(rmafile, martfile):
             # -- Get optimisation file name
             fopt = '.'.join(re.findall(re_fopt, line)[0])
             # -- Replace bye empty strings
-            new_line = re.sub(fopt,' '*len(fopt), line)
+            new_line = re.sub(fopt, ' ' * len(fopt), line)
             # -- Set changes inplace
             replace_text_in_file(rmafile, line, new_line)
 
@@ -420,12 +406,9 @@ def remove_autocal(rmafile, martfile):
         # -- Make calibration/optimisation silent 
         if cal_match is not None:
             wrong = cal_match.group()
-            right = re.sub('1','0', wrong)
-            new_line  = re.sub(wrong, right, line)
+            right = re.sub('1', '0', wrong)
+            new_line = re.sub(wrong, right, line)
             replace_text_in_file(martfile, line, new_line)
-
-
-
 
 
 def make_silent(martfile):
@@ -459,10 +442,9 @@ def make_silent(martfile):
         # ---- Make run silent 
         if exe_match is not None:
             wrong = exe_match.group()
-            right = re.sub(r'(\s|\w)=','M=', wrong)
-            new_line  = re.sub(wrong, right, line)
+            right = re.sub(r'(\s|\w)=', 'M=', wrong)
+            new_line = re.sub(wrong, right, line)
             replace_text_in_file(martfile, line, new_line)
-
 
 
 def get_chasim_indexer(chasim):
@@ -495,7 +477,7 @@ def get_chasim_indexer(chasim):
 
     """
     # -- Extract chasim content as string
-    with open(chasim, 'r', encoding = encoding) as f:
+    with open(chasim, 'r', encoding=encoding) as f:
         content = f.read()
 
     # -- Set regular expressions
@@ -504,28 +486,26 @@ def get_chasim_indexer(chasim):
 
     # -- Extract only usefull grid informations into a indexer DataFrame
     indexer = pd.DataFrame(
+        np.column_stack(
+            [
                 np.column_stack(
-                    [ 
-                    np.column_stack(
-                        [re.findall(r, content) for r in re_headers]
-                        ),
-                    np.column_stack(
-                        [[m.start(0), m.end(0)] for m in re.finditer(re_igrid, content, re.DOTALL)]
-                        ).T
-                    ]
+                    [re.findall(r, content) for r in re_headers]
                 ),
-            columns = ['field', 'istep', 'start', 'end']
-            ).astype(
-                {col: int for col in ['istep', 'start', 'end']}
-                )
+                np.column_stack(
+                    [[m.start(0), m.end(0)] for m in re.finditer(re_igrid, content, re.DOTALL)]
+                ).T
+            ]
+        ),
+        columns=['field', 'istep', 'start', 'end']
+    ).astype(
+        {col: int for col in ['istep', 'start', 'end']}
+    )
 
     # -- Return indexer
     return indexer
 
 
-
 def read_grid_file(grid_file, keep_adj=False, start=None, end=None):
-
     """
     Function to read Marthe grid data in file.
     Only structured grids are supported.
@@ -556,22 +536,22 @@ def read_grid_file(grid_file, keep_adj=False, start=None, end=None):
 
     """
     # ---- Extract data as large string
-    with open(grid_file, 'r', encoding = encoding) as f:
+    with open(grid_file, 'r', encoding=encoding) as f:
         allcontent = f.read()
         # -- Manage start/end input 
         starts = [0] if start is None else make_iterable(start)
         ends = [len(allcontent)] if end is None else make_iterable(end)
         # -- Get subseted content
-        content = ''.join([allcontent[s:e] for s,e in zip(starts, ends)])
+        content = ''.join([allcontent[s:e] for s, e in zip(starts, ends)])
 
     # ---- Define data regex
-    sgrid, scgrid, egrid, cxdx0, cydy0, cxdx1, cydy1 =  [r'\[Data]',
-                                                         r'\[Constant_Data]',
-                                                         r'\[End_Grid]',
-                                                         r'\[Columns_x_and_dx]',
-                                                         r'\[Rows_y_and_dy]',
-                                                         r'\[Num_Columns_/_x_/_dx]',
-                                                         r'\[Num_Rows_/_y_/_dy]']
+    sgrid, scgrid, egrid, cxdx0, cydy0, cxdx1, cydy1 = [r'\[Data]',
+                                                        r'\[Constant_Data]',
+                                                        r'\[End_Grid]',
+                                                        r'\[Columns_x_and_dx]',
+                                                        r'\[Rows_y_and_dy]',
+                                                        r'\[Num_Columns_/_x_/_dx]',
+                                                        r'\[Num_Rows_/_y_/_dy]']
 
     # ---- Define infos regex
     re_headers = [r"Field=(.+)\n",
@@ -593,14 +573,14 @@ def read_grid_file(grid_file, keep_adj=False, start=None, end=None):
     # ---- Iterate over each grid
     grid_list = []
 
-    for field, istep, layer, inest, xl, yl , ncol, nrow, str_grid_tup in zip(*headers, str_grids):
+    for field, istep, layer, inest, xl, yl, ncol, nrow, str_grid_tup in zip(*headers, str_grids):
         # ---- Get 
         data_type, str_grid = str_grid_tup
         # ---- Manage uniform value
         if data_type in scgrid:
             # -- Search and convert uniform value to float
             value = float(re.search(r"Uniform_Value=([-+]?\d*\.?\d+|\d+)",
-                          str_grid).group(1))
+                                    str_grid).group(1))
             # ---- Support different version of uniform headers (cxdx0 or cxdx1)
             if all(s in str_grid for s in [cxdx0, cydy0]):
                 cxdx, cydy = cxdx0, cydy0
@@ -608,21 +588,21 @@ def read_grid_file(grid_file, keep_adj=False, start=None, end=None):
                 cxdx, cydy = cxdx1, cydy1
 
             # -- Search x/y cell centers and x/y cell resolution
-            search = re.search(r"{0}\n{2}{1}\n{2}".format(cxdx, cydy, r'(.*?)\n'*3),
+            search = re.search(r"{0}\n{2}{1}\n{2}".format(cxdx, cydy, r'(.*?)\n' * 3),
                                str_grid, re.DOTALL)
-            
+
             # -- Fetch all rows, columns, cellcenters and dx, dy
             cols, xcc, dx, rows, ycc, dy = map(np.array,
-                                           map(str.split,
-                                            [search.group(i+1) for i in range(6)]))
+                                               map(str.split,
+                                                   [search.group(i + 1) for i in range(6)]))
             # -- Build uniform array
-            array = np.full((len(rows),len(cols)), value)
+            array = np.full((len(rows), len(cols)), value)
         else:
             # -- Extract 2D-array from string
-            arr_list = [np.fromstring(line.strip(), sep='\t', dtype = float)
+            arr_list = [np.fromstring(line.strip(), sep='\t', dtype=float)
 
-                       for line
-                       in str_grid.splitlines()]
+                        for line
+                        in str_grid.splitlines()]
             array = np.stack([a[2:-1] for a in arr_list[2:-1]], axis=0)
             # -- Convert to mask array if nested
             # if float(inest) > 0:
@@ -631,7 +611,7 @@ def read_grid_file(grid_file, keep_adj=False, start=None, end=None):
             #             fill_value = -9999.)
             # -- Search x/y cell centers and x/y cell resolution
             xcc, dx = arr_list[1][2:], arr_list[-1][2:]
-            ycc, dy = np.dstack([l[[1,-1]] for l in arr_list[2:-1]])[0]
+            ycc, dy = np.dstack([l[[1, -1]] for l in arr_list[2:-1]])[0]
         # -- Switch to 0-based
         layer = int(layer) - 1
         # -- Store arguments in tuple
@@ -641,8 +621,8 @@ def read_grid_file(grid_file, keep_adj=False, start=None, end=None):
             if int(inest) > 0:
                 # -- Remove first and last element on i and j data 
                 #    corresponding to neighbor cell of the main grids
-                args = ( istep, layer, inest, int(nrow)-2, int(ncol)-2, xl, yl,
-                         dx[1:-1], dy[1:-1], xcc[1:-1],ycc[1:-1], array[1:-1,1:-1], field )
+                args = (istep, layer, inest, int(nrow) - 2, int(ncol) - 2, xl, yl,
+                        dx[1:-1], dy[1:-1], xcc[1:-1], ycc[1:-1], array[1:-1, 1:-1], field)
             else:
                 args = (istep, layer, inest, nrow, ncol, xl, yl, dx, dy, xcc, ycc, array, field)
         # args = (istep, layer, inest, nrow, ncol, xl, yl, dx, dy, xcc, ycc, array, field)
@@ -651,18 +631,15 @@ def read_grid_file(grid_file, keep_adj=False, start=None, end=None):
 
     # ---- Raise error if marthe grid file headers are not provided
     err_msg = f"ERROR : uncorrect headers values in `{grid_file}` grid file.\n" \
-               "Check and correct the following lines:\n" \
-               "\t-'Layer='\n" \
-               "\t-'Max_Layer='\n" \
-               "\t-'Nest_grid='\n" \
-               "\t-'Max_NestG='\n"
+              "Check and correct the following lines:\n" \
+              "\t-'Layer='\n" \
+              "\t-'Max_Layer='\n" \
+              "\t-'Nest_grid='\n" \
+              "\t-'Max_NestG='\n"
     assert all(mg.layer >= 0 for mg in grid_list), err_msg
 
     # ---- Return all MartheGrid instances and xcc, ycc if required
     return tuple(grid_list)
-
-
-
 
 
 def replace_text_in_file(file, match, subs, flags=0):
@@ -706,8 +683,6 @@ def replace_text_in_file(file, match, subs, flags=0):
         f.write(new_text)
 
 
-
-
 def get_units_dic(martfile):
     """
     -----------
@@ -731,15 +706,15 @@ def get_units_dic(martfile):
     """
     # ---- Set unit names
     unit_names = ['permh', 'flow', 'head', 'emmca', 'emmli', 'climh',
-                  'irrigh', 'climtime', 'modeltime', 'modeldist', 
+                  'irrigh', 'climtime', 'modeltime', 'modeldist',
                   'vani', 'hani', 'emmcatype', 'salinity', 'concentration',
                   'porosity', 'stock', 'mass', 'permtype', 'volume', 'massflowtype']
 
     # ---- Set time unit dictionary 
-    tu_dic = {'SEC':'S', 'MIN':'T', 'HEU':'H', 'JOU':'D',
-              'SEM': 'W', 'MOI': 'M', 'ANN':'Y',
-              'seconde':'S', 'minute': 'T', 'heure':'H',
-              'jour':'J', 'semaine':'W', 'mois': 'M', 'année':'Y'}
+    tu_dic = {'SEC': 'S', 'MIN': 'T', 'HEU': 'H', 'JOU': 'D',
+              'SEM': 'W', 'MOI': 'M', 'ANN': 'Y',
+              'seconde': 'S', 'minute': 'T', 'heure': 'H',
+              'jour': 'J', 'semaine': 'W', 'mois': 'M', 'année': 'Y'}
 
     # ---- Fetch .mart file content
     with open(martfile, 'r', encoding=encoding) as f:
@@ -762,7 +737,7 @@ def get_units_dic(martfile):
             v = None
         # -- Manage time units
         elif val_str in tu_dic.keys():
-                v = tu_dic[val_str]
+            v = tu_dic[val_str]
         # -- Manage val_str as value or str unit
         else:
             # -- Correct bad scientific notation
@@ -777,8 +752,6 @@ def get_units_dic(martfile):
 
     # ---- Return units
     return units_dic
-
-
 
 
 def get_dates(pastp_file, mart_file):
@@ -814,14 +787,13 @@ def get_dates(pastp_file, mart_file):
         # -- Build dates
         dates = pd.TimedeltaIndex([s + tu for s in dates_str])
     else:
-        dates = pd.DatetimeIndex(dates_str, dayfirst = True)
+        dates = pd.DatetimeIndex(dates_str, dayfirst=True)
 
     # ---- Return dates
     return dates
 
 
-
-def read_prn(prnfile = 'historiq.prn'):
+def read_prn(prnfile='historiq.prn'):
     """
     Function to read simulated prn file
 
@@ -851,20 +823,20 @@ def read_prn(prnfile = 'historiq.prn'):
     add_skip = 1
     with open(prnfile, 'r', encoding=encoding) as f:
         # ----Fetch 5 first lines of prn file 
-        
+
         # am 2023-11-24 : in some version of marthe, no empty col at the end of file.
         # using [:-1] would drop a real column and raise error while renaming columns in line 904
         # flines_arr = np.array([f.readline().split('\t')[:-1] for i in range(5)], dtype=list)
         flines_arr = np.array([f.readline().split('\t') for i in range(5)], dtype=list)
 
         # ---- Create a boolean mask to read only usefull header lines
-        mask = [False, True, False, True , False]
+        mask = [False, True, False, True, False]
         # ---- Select only usefull first lines by mask
         if any('Main_Grid' in elem for elem in flines_arr[-2]):
-            nest = True 
+            nest = True
             # -- Transform to fancy integer 'inest' number
             flines_arr[-2] = ['0' if not 'Gigogne' in g else g.split(':')[1].strip()
-                                  for g in flines_arr[-2]]
+                              for g in flines_arr[-2]]
             # -- Add -gigone- boolean to mask
             mask[-1] = nest
         else:
@@ -881,24 +853,24 @@ def read_prn(prnfile = 'historiq.prn'):
         idx_names = ['type', 'name']
     # identify whether a date columns is provided in addition to simulation time
     # (this implies 2 subsequent '#_Date' columns in the prn)
-    date_col = headers[0][0].strip(' ')==headers[0][1].strip(' ')
+    date_col = headers[0][0].strip(' ') == headers[0][1].strip(' ')
     # remove time column and parse dates when date column is present
     if date_col:
         # ---- Get all headers as tuple
-        tuples = [tuple(map(str.strip,list(t)) ) for t in list(zip(*headers))][2:]
+        tuples = [tuple(map(str.strip, list(t))) for t in list(zip(*headers))][2:]
         # ---- Read prn file without headers (with date format)
-        df = pd.read_csv(prnfile, sep='\t', encoding=encoding, 
-                         skiprows=mask.count(True) + add_skip, index_col = 0,
-                         parse_dates = True, dayfirst=True)
+        df = pd.read_csv(prnfile, sep='\t', encoding=encoding,
+                         skiprows=mask.count(True) + add_skip, index_col=0,
+                         parse_dates=True, dayfirst=True)
         # am 2023-11-24: in recent version of pandas, inplace is not authorized anymore
         # df.drop(df.columns[0], axis=1,inplace=True)
         df = df.drop(df.columns[0], axis=1)
-    else :
+    else:
         # ---- Get all headers as tuple
-        tuples = [tuple(map(str.strip,list(t)) ) for t in list(zip(*headers))][1:]
+        tuples = [tuple(map(str.strip, list(t))) for t in list(zip(*headers))][1:]
         # ---- Read prn file without headers (time is not a date)
-        df = pd.read_csv(prnfile, sep='\t', encoding=encoding, 
-                         skiprows=mask.count(True) + add_skip, index_col = 0,
+        df = pd.read_csv(prnfile, sep='\t', encoding=encoding,
+                         skiprows=mask.count(True) + add_skip, index_col=0,
                          )
     # ---- Format DateTimeIndex or float
     df.index.name = 'date'
@@ -908,17 +880,15 @@ def read_prn(prnfile = 'historiq.prn'):
     # am 2023-11-24: in recent version of pandas, inplace is not authorized anymore
     # and move after multiindex to avoid error on len(tupes) vs. len(df.columns)
     # df.dropna(axis=1, how = 'all', inplace = True)  # drop empty columns if exists
-    df = df.dropna(axis=1, how = 'all')  # drop empty columns if exists
+    df = df.dropna(axis=1, how='all')  # drop empty columns if exists
     # ---- Trandform inest id to integer
     if nest:
         levels = df.columns.get_level_values('inest').astype(int).unique()
         # am 2023-11-24: in recent version of pandas, inplace is not authorized anymore
         # df.columns.set_levels(levels = levels, level='inest', inplace=True)
-        df.columns = df.columns.set_levels(levels = levels, level='inest')
+        df.columns = df.columns.set_levels(levels=levels, level='inest')
     # ---- Return prn DataFrame
     return df
-
-
 
 
 def read_histo_file(histo_file):
@@ -946,7 +916,7 @@ def read_histo_file(histo_file):
     re_nest = r'^\s*\d*/\w+'
     re_names = r";\s*(.*)"
     # ---- Fetch histo file content by line
-    with open(histo_file, encoding = encoding) as f:
+    with open(histo_file, encoding=encoding) as f:
         lines = [line.rstrip() for line in f]
     # ---- Iterate over all lines
     data = []
@@ -957,29 +927,28 @@ def read_histo_file(histo_file):
             inest = int(inest_str) if inest_str else 0
             # ---- Fetch cell localisation
             if '/XCOO' in line:
-                loc_str = line[line.index('X='):line.index(';')] 
+                loc_str = line[line.index('X='):line.index(';')]
                 loc_type = 'xyz'
             if '/MAIL' in line:
                 loc_str = line[line.index('C='):line.index(';')]
                 loc_type = 'clp'
             loc = list(map(ast.literal_eval, re.findall(re_num, loc_str)))
             # ---- Fetch id and label (void older version with 'Name='' tag)
-            names = re.split(r"\s{5,}", re.split(';', re.sub('Name=','',line))[-1].strip())
+            names = re.split(r"\s{5,}", re.split(';', re.sub('Name=', '', line))[-1].strip())
             # ---- Manage undefined label
-            names = names*2 if len(names) == 1 else names
+            names = names * 2 if len(names) == 1 else names
             # ---- Store cell data
             data.append([typ, inest, loc_type] + loc + names)
     # ---- Build histo DataFrame
-    cols = ['type','inest','loc_type','x','y','layer','id', 'label']
-    df = pd.DataFrame(data, columns = cols)
+    cols = ['type', 'inest', 'loc_type', 'x', 'y', 'layer', 'id', 'label']
+    df = pd.DataFrame(data, columns=cols)
     # convert layer to 0_based
-    df['layer'] = df.layer - 1 
+    df['layer'] = df.layer - 1
     print('INFO : layer id in read_histo_file df is 0-based.')
     # am: remove inplace for pandas (>=2.0)
     df = df.set_index('id')
     # ---- Return histo DataFrame
     return df
-
 
 
 def isiterable(object):
@@ -1008,10 +977,9 @@ def isiterable(object):
     else:
         try:
             it = iter(object)
-        except TypeError: 
+        except TypeError:
             return False
         return True
-
 
 
 def make_iterable(var):
@@ -1036,19 +1004,35 @@ def make_iterable(var):
     return it
 
 
-
-
 def read_listm_qfile(qfile, istep, fmt):
     """
+
+    Parameters
+    ----------
+    qfile
+    istep
+    fmt
+
+    Returns
+    -------
+
     """
-    if (len(fmt) == 0) | ('Somm_Mail|C_L_P|Keep_9999' in fmt): 
-        # ---- Set data types
-        dt = {'value':'f8','j':'i4','i':'i4','layer':'i4'}
-        # ---- Read qfile as DataFrame (separator = any whitespace)
-        df = pd.read_csv(qfile, encoding=encoding, delim_whitespace=True,
-                         header=None, names=list(dt.keys()), dtype=dt)
+    def open_with_spec_columns(qfile: str, dict_col:  dict[str,str]):
+        # ---- Read qfile as a DataFrame and infer the header
+        df = pd.read_csv(qfile, encoding=encoding, sep=r'\s+', header='infer')
+        # ---- Changes columns names and types using dict_col argument
+        df.columns = list(dt.keys())
+        for col, typ in dt.items():
+            df[col] = df[col].astype(typ)
+        return df
+
+    if (len(fmt) == 0) | ('Somm_Mail|C_L_P|Keep_9999' in fmt):
+        # ---- It defined a wish columns names and types
+        dt = {'value': 'f8', 'j': 'i4', 'i': 'i4', 'layer': 'i4'}
+        # ---- Read qfile as DataFrame and modifies columns names and types
+        df = open_with_spec_columns(qfile, dt)
         # ---- Pass t0 0-based
-        df[['j','i','layer']] = df[['j','i','layer']].sub(1)
+        df[['j', 'i', 'layer']] = df[['j', 'i', 'layer']].sub(1)
         # ---- Add istep
         df['istep'] = istep
         df['boundname'] = 'boundname'
@@ -1057,15 +1041,14 @@ def read_listm_qfile(qfile, istep, fmt):
         df[metacols] = np.array([qfile, 'listm', df.index, 0], dtype=object)
         # ---- Return data
         cols = ['istep', 'layer', 'i', 'j', 'value', 'boundname']
-        _cols = cols + metacols 
+        _cols = cols + metacols
         return df[cols], df[_cols]
 
     if 'X_Y_C|Somm_Mail|Keep_9999' in fmt:
-        # ---- Set data types
-        dt = {'x':'f8','y':'f8','layer':'i4', 'value':'f8'}
-        # ---- Read qfile as DataFrame (separator = any whitespace)
-        df = pd.read_csv(qfile, encoding=encoding, delim_whitespace=True,
-                         header=None, names=list(dt.keys()), dtype=dt)
+        # ---- It defined a wish columns names and types
+        dt = {'x': 'f8', 'y': 'f8', 'layer': 'i4', 'value': 'f8'}
+        # ---- Read qfile as DataFrame and modifies columns names and types
+        df = open_with_spec_columns(qfile, dt)
         # ---- Pass t0 0-based
         df['layer'] = df['layer'].sub(1)
         # ---- Add istep
@@ -1076,15 +1059,14 @@ def read_listm_qfile(qfile, istep, fmt):
         df[metacols] = np.array([qfile, 'listm', df.index, 3], dtype=object)
         # ---- Return data
         cols = ['istep', 'layer', 'x', 'y', 'value', 'boundname']
-        _cols = cols + metacols 
+        _cols = cols + metacols
         return df[cols], df[_cols]
 
-    if  'X_Y_V|Somm_Mail|Keep_9999' in fmt:
-        # ---- Set data types
-        dt = {'x':'f8','y':'f8', 'value':'f8'}
-        # ---- Read qfile as DataFrame (separator = any whitespace)
-        df = pd.read_csv(qfile, encoding=encoding, delim_whitespace=True,
-                         header=None, names=list(dt.keys()), dtype=dt)
+    if 'X_Y_V|Somm_Mail|Keep_9999' in fmt:
+        # ---- It defined a wish columns names and types
+        dt = {'x': 'f8', 'y': 'f8', 'value': 'f8'}
+        # ---- Read qfile as DataFrame and modifies columns names and types
+        df = open_with_spec_columns(qfile, dt)
         # ---- Add layer info (=0)
         df['layer'] = 0
         # ---- Add istep
@@ -1095,36 +1077,31 @@ def read_listm_qfile(qfile, istep, fmt):
         df[metacols] = np.array([qfile, 'listm', df.index, 2], dtype=object)
         # ---- Return data
         cols = ['istep', 'layer', 'x', 'y', 'value', 'boundname']
-        _cols = cols + metacols 
+        _cols = cols + metacols
         return df[cols], df[_cols]
 
 
-
-
-
-def read_record_qfile(i,j,k,v,qfile,qcol):
+def read_record_qfile(i, j, k, v, qfile, qcol):
     """
     """
     # ---- Read just qcol column in qfile
-    data = pd.read_csv(qfile, encoding=encoding, delim_whitespace=True)
+    data = pd.read_csv(qfile, encoding=encoding, sep=r'\s+')
     # ---- Extract boundname and value
     bdnme = 'boundname'
-    value = [v] + data.iloc[:,qcol].to_list()
+    value = [v] + data.iloc[:, qcol].to_list()
     istep = qrow = list(range(len(value)))
-    df = pd.DataFrame({'istep':istep,'layer':k,'i': i,'j':j,
+    df = pd.DataFrame({'istep': istep, 'layer': k, 'i': i, 'j': j,
                        'value': value, 'boundname': bdnme,
                        'qfilename': qfile, 'qtype': 'record',
                        'qrow': qrow, 'qcol': qcol})
     # ---- Return data
     cols = ['istep', 'layer', 'i', 'j', 'value', 'boundname']
-    metacols =  ['qfilename', 'qtype', 'qrow', 'qcol']
+    metacols = ['qfilename', 'qtype', 'qrow', 'qcol']
     _cols = cols + metacols
     return df[cols], df[_cols]
 
 
-
-
-def extract_pastp_pumping(pastpfile, mode = 'aquifer'):
+def extract_pastp_pumping(pastpfile, mode='aquifer'):
     """
     -----------
     Description:
@@ -1156,7 +1133,7 @@ def extract_pastp_pumping(pastpfile, mode = 'aquifer'):
     # ---- Prepare some usefull regex
     re_block = r";\s*\*{3}\n(.*?)/\*{5}"
     re_num = r"[-+]?\d*\.?\d+|\d+"
-    re_jikv = r"C=\s*({})L=\s*({})P=\s*({})V=\s*({});".format(*[re_num]*4)
+    re_jikv = r"C=\s*({})L=\s*({})P=\s*({})V=\s*({});".format(*[re_num] * 4)
     re_file = r"\s*File=\s*(.*)\.(\w{3})"
     re_col = r"\s*Col=\s*({})".format(re_num)
     re_listm_fmt = r'(?<=<)[^<:]+(?=:?>)'
@@ -1181,7 +1158,7 @@ def extract_pastp_pumping(pastpfile, mode = 'aquifer'):
         # ---- Iterate over block content (lines)
         for line in block.splitlines():
             # -- Check if a pumping condition is applied
-             if mode_tag in line:
+            if mode_tag in line:
                 # -- Check which type of pumping condition is provided 
                 # 1) Manage LIST_MAIL (list of pumping cells in external file)
                 if any(s in line for s in ['/LISTM', '/LIST_M']):
@@ -1192,21 +1169,21 @@ def extract_pastp_pumping(pastpfile, mode = 'aquifer'):
                     df, _df = read_listm_qfile(qfilename, istep, fmt)
                 # 2) Manage MAILLE (unique pumping cell)
                 if '/MAIL' in line:
-                    j,i,k,v = map(ast.literal_eval, re.findall(re_jikv, line)[0])
+                    j, i, k, v = map(ast.literal_eval, re.findall(re_jikv, line)[0])
                     _file, _col = [re.search(r, line) for r in [re_file, re_col]]
                     # -- Convert to 0-based
-                    qcol = 0 if _col is None else int(_col.group(1)) -1
-                    k,i,j = k-1,i-1,j-1
+                    qcol = 0 if _col is None else int(_col.group(1)) - 1
+                    k, i, j = k - 1, i - 1, j - 1
                     if _file is None:
                         bdnme = 'boundname'
-                        df = pd.DataFrame([[istep,k,i,j,v,bdnme]],
-                             columns=['istep','layer','i','j','value','boundname'])
+                        df = pd.DataFrame([[istep, k, i, j, v, bdnme]],
+                                          columns=['istep', 'layer', 'i', 'j', 'value', 'boundname'])
                         _df = df.copy(deep=True)
-                        _df[['qfilename', 'qtype', 'qrow','qcol']] = [None, 'mail', None, None]
+                        _df[['qfilename', 'qtype', 'qrow', 'qcol']] = [None, 'mail', None, None]
                     else:
 
                         qfilename = os.path.normpath(os.path.join(mm_ws, f"{_file.group(1)}.{_file.group(2)}"))
-                        df, _df = read_record_qfile(i,j,k,v, qfilename, qcol)
+                        df, _df = read_record_qfile(i, j, k, v, qfilename, qcol)
 
                 # ---- Append (meta)DataFrame list
                 dfs.append(df)
@@ -1215,9 +1192,6 @@ def extract_pastp_pumping(pastpfile, mode = 'aquifer'):
     # ---- Return concatenate (meta)DataFrame
     data, metadata = [df.reset_index(drop=True) for df in list(map(pd.concat, [dfs, _dfs]))]
     return data, metadata
-
-
-
 
 
 def convert_at2clp(pastpfile, mm):
@@ -1258,7 +1232,7 @@ def convert_at2clp(pastpfile, mm):
     with open(pastpfile, 'r', encoding=encoding) as f:
         # ---- Extract pastp by block 
         blocks = re.findall(re_block, f.read(), re.DOTALL)
-    
+
     # ---- Set boolean marker to know if at list one convertion had been done
     any_at = []
 
@@ -1267,7 +1241,7 @@ def convert_at2clp(pastpfile, mm):
         # ---- Iterate over block content (lines)
         for line in block.splitlines():
             # ---- Check if the line contain aff/trc
-            if all(s in line for s in ['Q_EXTER_RIVI','A=','T=']):
+            if all(s in line for s in ['Q_EXTER_RIVI', 'A=', 'T=']):
                 # -- Detect conversion
                 any_at.append(True)
                 # -- Replace TRONCON to MAILLE
@@ -1275,27 +1249,25 @@ def convert_at2clp(pastpfile, mm):
                 # -- Get substring to replace
                 s2replace = line[line.index('A='):line.index('V=')]
                 # -- Fetch aff/trc as number
-                a,t = map(ast.literal_eval, re.findall(re_num, s2replace))
+                a, t = map(ast.literal_eval, re.findall(re_num, s2replace))
                 # ---- Convert aff/trc to column, line, plan (layer) by querying the grid
-                i, j, layer = mm.query_grid(aff=a, trc=t, target=['i','j','layer']).to_numpy()[0]
+                i, j, layer = mm.query_grid(aff=a, trc=t, target=['i', 'j', 'layer']).to_numpy()[0]
                 # -- Build substring to replace
-                sub = '{:>8}C={:>7}L={:>7}P={:>7}'.format(' ',j+1, i+1, layer+1)
+                sub = '{:>8}C={:>7}L={:>7}P={:>7}'.format(' ', j + 1, i + 1, layer + 1)
                 # -- Build entire line to be replaced for
-                l2replace = mail_line.replace(s2replace,sub)
+                l2replace = mail_line.replace(s2replace, sub)
                 # -- Replace text in pastp file
                 replace_text_in_file(pastpfile, line, l2replace)
 
     # ---- User warning about aff/trc conversion
     if len(any_at) > 0:
         msg = f"WARNINGS : some river pumpings in {pastpfile} file are " \
-               "located by there 'tributary' and 'reach' ids which is not supported. " \
-               "They will be converted to 'row', 'column', 'layer' format instead (inplace)."
+              "located by there 'tributary' and 'reach' ids which is not supported. " \
+              "They will be converted to 'row', 'column', 'layer' format instead (inplace)."
         warnings.warn(msg)
 
 
-
-
-def remove_no_data_values(df, column = 'value', nodata = NO_DATA_VALUES):
+def remove_no_data_values(df, column='value', nodata=NO_DATA_VALUES):
     """
     -----------
     Description
@@ -1331,8 +1303,7 @@ def remove_no_data_values(df, column = 'value', nodata = NO_DATA_VALUES):
         return df.dropna()
 
 
-
-def read_obsfile(obsfile, nodata = None):
+def read_obsfile(obsfile, nodata=None):
     """
     Simple function to read observation file.
     Format : header0        header1
@@ -1360,15 +1331,14 @@ def read_obsfile(obsfile, nodata = None):
     obs_df = read_obsfile(obsfile = 'myobs.dat')
     """
     # ---- Read obsfile
-    data = pd.read_csv(obsfile, delim_whitespace=True,
-                                header=None, skiprows=1,
-                                index_col=0, parse_dates=True)
+    data = pd.read_csv(obsfile, sep=r'\s+',
+                       header=None, skiprows=1,
+                       index_col=0, parse_dates=True)
     # ---- Set standard column names
-    df = data.rename(columns = {1 :'value'})
+    df = data.rename(columns={1: 'value'})
     df.index.name = 'date'
     # ----- Return clean DataFrame
-    return remove_no_data_values(df, nodata = nodata)
-
+    return remove_no_data_values(df, nodata=nodata)
 
 
 def write_obsfile(date, value, obsfile):
@@ -1394,14 +1364,12 @@ def write_obsfile(date, value, obsfile):
     obs_df = write_obsfile(date, values, obsfile = locnme + '.dat')
     """
     # ---- Build standard DataFrame
-    df = pd.DataFrame(dict(value = list(value)), index = date)
+    df = pd.DataFrame(dict(value=list(value)), index=date)
     # ---- Write DataFrame
-    df.to_csv(obsfile,  sep = '\t', header = True, index = True)
+    df.to_csv(obsfile, sep='\t', header=True, index=True)
 
 
-
-
-def get_run_times(logfile = 'bilandeb.txt'):
+def get_run_times(logfile='bilandeb.txt'):
     """
     Extract run times for model processes from log file.
 
@@ -1431,7 +1399,7 @@ def get_run_times(logfile = 'bilandeb.txt'):
     re_rt = r"Temps CPU\s*(pour|\s*)(.+)=\s*([-+]?\d*\.?\d+|\d+)"
 
     # -- Search pattern in logs and collect times
-    process, times = [],[]
+    process, times = [], []
     for _, p, t in re.findall(re_rt, content):
         pro = p.strip().capitalize()
         t = int(ast.literal_eval(t))
@@ -1448,10 +1416,7 @@ def get_run_times(logfile = 'bilandeb.txt'):
         times.append(time)
 
     # -- Return output DataFrame
-    return pd.DataFrame({'Process':process,'CPU time':times}).set_index('Process')
-
-
-
+    return pd.DataFrame({'Process': process, 'CPU time': times}).set_index('Process')
 
 
 def bordered_array(a, v):
@@ -1484,14 +1449,12 @@ def bordered_array(a, v):
     --------
     ba = bordered_array(np.ones((5,5)), 0)
     """
-    car = np.c_[np.ones(a.shape[0])*v, a, np.ones(a.shape[0])*v]
-    bar = np.c_[np.ones(car.shape[1])*v, car.T, np.ones(car.shape[1])*v]
+    car = np.c_[np.ones(a.shape[0]) * v, a, np.ones(a.shape[0]) * v]
+    bar = np.c_[np.ones(car.shape[1]) * v, car.T, np.ones(car.shape[1]) * v]
     return bar.T
 
 
-
-
-def read_budget(filename= 'histobil_nap_pastp.prn'):
+def read_budget(filename='histobil_nap_pastp.prn'):
     """
     Global budget reader (.prn).
     The `io.StringIO` module is required.
@@ -1529,7 +1492,7 @@ def read_budget(filename= 'histobil_nap_pastp.prn'):
     except:
         err_msg = 'Could not load python `io` module. '
         err_msg += 'Try `pip install io`.'
-        raise(ImportError(err_msg))
+        raise (ImportError(err_msg))
 
     # ---- Read raw data as string
     with open(filename, 'r', encoding=encoding) as f:
@@ -1542,12 +1505,12 @@ def read_budget(filename= 'histobil_nap_pastp.prn'):
     # ---- Extract budget(s)
     bud_dfs = []
     for table in tables:
-        if '<Date>' not in table[0]: 
+        if '<Date>' not in table[0]:
             # -- Convert string budget data to DataFrame (drop numeric date and NaN columns)
-            bud_df = pd.read_table( StringIO(table[0]),
-                                    index_col=0, parse_dates=True, dayfirst = True
-                                        ).dropna(
-                                            axis=1).iloc[:,1:]
+            bud_df = pd.read_table(StringIO(table[0]),
+                                   index_col=0, parse_dates=True, dayfirst=True
+                                   ).dropna(
+                axis=1).iloc[:, 1:]
             # -- Manage column names
             bud_df.columns = bud_df.columns.str.strip()
             bud_df.index.name = 'date'
@@ -1561,12 +1524,7 @@ def read_budget(filename= 'histobil_nap_pastp.prn'):
         return bud_dfs
 
 
-
-
-
-
-
-def read_zonebudget(filename= 'histobil_debit.prn'):
+def read_zonebudget(filename='histobil_debit.prn'):
     """
     Zone budget reader.
     The `io.StringIO` module is required.
@@ -1599,7 +1557,7 @@ def read_zonebudget(filename= 'histobil_debit.prn'):
     except:
         err_msg = 'Could not load python `io` module. '
         err_msg += 'Try `pip install io`.'
-        raise(ImportError(err_msg))
+        raise (ImportError(err_msg))
 
     # ---- Read raw data as string
     with open(filename, 'r', encoding=encoding) as f:
@@ -1609,20 +1567,20 @@ def read_zonebudget(filename= 'histobil_debit.prn'):
     re_zone = r"\n(\s*|.+)Zone(\s+|\s+=\s+)(\d+)\s*\n"
 
     get_re_zb = lambda z: ''.join(
-                            [ re_zone.replace(r'(\d+)', str(z)),
-                              r"(.+?)\n(Bilan|Zone|Débits|Légende)" ]
-                        )
+        [re_zone.replace(r'(\d+)', str(z)),
+         r"(.+?)\n(Bilan|Zone|Débits|Légende)"]
+    )
 
     # ---- Extract zone budget for each zones
     zb_dfs = []
 
     for match_zone in re.findall(re_zone, content):
         # -- Convert match to interger zone number
-        zone = int(match_zone[-1]) 
+        zone = int(match_zone[-1])
         # -- Extract string table with raw data
         zb_table = re.search(
-                        get_re_zb(zone), content, re.DOTALL
-                        ).group(3)
+            get_re_zb(zone), content, re.DOTALL
+        ).group(3)
         # -- Convert to DataFrame skiping the useless additional headers and NaN columns
         zb_df = pd.read_table(StringIO(zb_table), skiprows=[1]).dropna(axis=1)
         # -- Drop numeric date column
@@ -1632,7 +1590,7 @@ def read_zonebudget(filename= 'histobil_debit.prn'):
         # -- Manage column names
         zb_df.columns = ['date'] + list(zb_df.columns[1:].str.strip())
         # -- Convert date column to datetime format
-        zb_df['date'] = pd.to_datetime(zb_df['date'], dayfirst = True)
+        zb_df['date'] = pd.to_datetime(zb_df['date'], dayfirst=True)
         # -- Add a column with the zone id
         zb_df['zone'] = zone
         # -- Add zone budget to main list
@@ -1647,9 +1605,6 @@ def read_zonebudget(filename= 'histobil_debit.prn'):
 
     # ---- Return MultiIndex DataFrame
     return zb_df
-
-
-
 
 
 def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
@@ -1698,7 +1653,7 @@ def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
 
     """
     # ---- Read .pastp file by lines
-    with open(pastpfile, 'r', encoding = encoding) as f:
+    with open(pastpfile, 'r', encoding=encoding) as f:
         init = f.readlines()
 
     # ---- Clear existing hydrodynamic action
@@ -1714,7 +1669,7 @@ def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
                 if 'Fin de ce pas' in l:
                     break
             # -- Insert line to activate all timesteps (default) 
-            _l ='  /CALCUL_HDYNAM/ACTION    I= 1;\n'
+            _l = '  /CALCUL_HDYNAM/ACTION    I= 1;\n'
             nlines.insert(i, _l)
 
         # ---- Desactivate all timesteps
@@ -1724,7 +1679,7 @@ def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
                 if 'Fin de ce pas' in l:
                     break
             # -- Insert line to activate all timesteps (default)
-            _l ='  /CALCUL_HDYNAM/ACTION    I= -1;\n'
+            _l = '  /CALCUL_HDYNAM/ACTION    I= -1;\n'
             nlines.insert(i, _l)
 
         # ---- Manage string sequence to get istep 
@@ -1733,7 +1688,7 @@ def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
             nstep = len(re.findall(r'Fin de ce pas', ''.join(lines)))
             # -- Extract time bounds (start, end, step) as integers
             re_seq = r'(\d+|\s*):(\d+|\s*):(\d+)'
-            s, e, ii = re.findall(re_seq,istep)[0]
+            s, e, ii = re.findall(re_seq, istep)[0]
             start = eval(s) if s != '' else 0
             end = eval(e) if e != '' else nstep
             step = eval(ii) if ii != '' else 1
@@ -1760,7 +1715,7 @@ def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
             # -- Fetch timesteps calendar dates
             dates = re.findall(r'\d{2}\/\d{2}\/\d{4}', ''.join(lines))
             # -- Set external file header
-            s =  "HYDRODYNAMIC COMPUTATION PLANNING\n"
+            s = "HYDRODYNAMIC COMPUTATION PLANNING\n"
             # -- Iterate over all time steps (2 = active, 0 = inactive)
             for n, date in enumerate(dates):
                 # -- Active if in required timesteps desactive otherwise
@@ -1770,7 +1725,7 @@ def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
                     s += f'0\t{date}\n'
 
             # -- Write external file
-            with open(ext_path, 'w', encoding =encoding) as f:
+            with open(ext_path, 'w', encoding=encoding) as f:
                 f.write(s)
 
         # -- Manage internal mode
@@ -1786,9 +1741,9 @@ def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
                     n += 1
                     # -- Insert active/desative line
                     if n in isteps:
-                        nlines.insert(i+n,_l)
+                        nlines.insert(i + n, _l)
                     else:
-                        nlines.insert(i+n,__l)
+                        nlines.insert(i + n, __l)
 
     # -- (Over-)write pastp file 
     out = pastpfile if new_pastpfile is None else new_pastpfile
@@ -1797,9 +1752,7 @@ def hydrodyn_periodicity(pastpfile, istep, external=False, new_pastpfile=None):
 
     # -- Print final message
     print("==> Hydrodynamic computation periodicity " \
-          f"had been set successfully in '{out}'") 
-
-
+          f"had been set successfully in '{out}'")
 
 
 def set_tw(start=None, end=None, mm=None, martfile=None, pastpfile=None):
@@ -1901,7 +1854,7 @@ def set_tw(start=None, end=None, mm=None, martfile=None, pastpfile=None):
     # ---- Assert that start < end
     err_msg = "ERROR : `end` timestep must be greater than `start`. " \
               "Given : {}, {}.".format(*tbounds)
-    assert np.logical_or(istart < iend, iend == 0) , err_msg
+    assert np.logical_or(istart < iend, iend == 0), err_msg
 
     # ---- Extract .mart file content
     with open(martfile, encoding=encoding) as f:
@@ -1915,14 +1868,14 @@ def set_tw(start=None, end=None, mm=None, martfile=None, pastpfile=None):
     # ---- Extract required lines
     for i, line in enumerate(lines):
         if re.search(re_block, line) is not None:
-            start_line = lines[i+4]
-            end_line = lines[i+1]
+            start_line = lines[i + 4]
+            end_line = lines[i + 1]
             new_start_line = '{}{}={}'.format(re.search(re_bef, start_line).group(1),
                                               istart,
                                               '='.join(start_line.split('=')[1:]))
             new_end_line = '{}{}={}'.format(re.search(re_bef, end_line).group(1),
-                                              iend,
-                                              '='.join(end_line.split('=')[1:]))
+                                            iend,
+                                            '='.join(end_line.split('=')[1:]))
             break
 
     # ---- Replace start line
@@ -1934,9 +1887,6 @@ def set_tw(start=None, end=None, mm=None, martfile=None, pastpfile=None):
     # -- Print final message
     print(f"==> Model time window had been set from istep " \
           f"{istart} to {iend} successfully. ")
-
-
-
 
 
 def get_tw(mm=None, martfile=None, pastpfile=None, tw_type='date'):
@@ -1999,9 +1949,9 @@ def get_tw(mm=None, martfile=None, pastpfile=None, tw_type='date'):
 
     # ---- Extract required lines
     for i, line in enumerate(lines):
-        if re.search(re_block, line) is not None: 
-            tw_min = tw_infer(re.search(re_istep, lines[i+4]))
-            tw_max = tw_infer(re.search(re_istep, lines[i+1]))
+        if re.search(re_block, line) is not None:
+            tw_min = tw_infer(re.search(re_istep, lines[i + 4]))
+            tw_max = tw_infer(re.search(re_istep, lines[i + 1]))
             break
 
     # ---- Fetch model dates from .pastp file
@@ -2017,4 +1967,3 @@ def get_tw(mm=None, martfile=None, pastpfile=None, tw_type='date'):
 
     elif tw_type == 'istep':
         return tw_min, tw_max
-

--- a/pymarthe/utils/marthe_utils.py
+++ b/pymarthe/utils/marthe_utils.py
@@ -411,15 +411,14 @@ def remove_autocal(rmafile, martfile):
             replace_text_in_file(martfile, line, new_line)
 
 
-def make_silent(martfile):
+def set_verbosity(martfile, silent: bool):
     """
-    Function to make marthe run silent
+    Function to run marthe model either silently or with verbose output
 
     Parameters:
     ----------
-    self : MartheModel instance
     martfile (str) : .mart file path
-                      Default is None
+    silent (bool) : silent mode or not
 
     Returns:
     --------
@@ -427,7 +426,7 @@ def make_silent(martfile):
 
     Examples:
     --------
-    make_silent('mymodel.mart')
+    set_verbosity('mymodel.mart',silent=True)
     """
     # ---- Fetch .mart file content
     with open(martfile, 'r', encoding=encoding) as f:
@@ -442,7 +441,10 @@ def make_silent(martfile):
         # ---- Make run silent 
         if exe_match is not None:
             wrong = exe_match.group()
-            right = re.sub(r'(\s|\w)=', 'M=', wrong)
+            if silent:
+                right = re.sub(r'(\s|\w)=', 'M=', wrong)
+            else:
+                right = re.sub(r'(\s|\w)=', ' =', wrong)
             new_line = re.sub(wrong, right, line)
             replace_text_in_file(martfile, line, new_line)
 

--- a/pymarthe/utils/pest_utils.py
+++ b/pymarthe/utils/pest_utils.py
@@ -264,7 +264,7 @@ def read_config(configfile):
     re_hblock = r'\*{3}(.+?)\*{3}'
     re_pblock = r'\[START_PARAM\](.+?)\[END_PARAM\]'
     re_oblock = r'\[START_OBS\](.+?)\[END_OBS\]'
-    re_item_hblock = r'(.+):\s*(.+)\n'
+    re_item_hblock = r'(.+?):\s*(.+)\n'
     re_item_block = r'(.+)=\s*(.+)\n'
     
 

--- a/pymarthe/utils/pest_utils.py
+++ b/pymarthe/utils/pest_utils.py
@@ -507,10 +507,7 @@ def run_from_config(configfile, run_model=True, **kwargs):
     # -- Run model
     print('\t-> Running model with updated parameters')
     if run_model:
-        success, output_lines = mm.run_model(**kwargs)
-        if not success:
-            print("\n".join(output_lines))
-            raise RuntimeError("Model run failed. See output above.")
+         mm.run_model(**kwargs)
     # -- Extract simulated data
     print('\t-> Extracting simulated values')
     prn = marthe_utils.read_prn(os.path.join(mm.mldir,'historiq.prn'))

--- a/pymarthe/utils/pest_utils.py
+++ b/pymarthe/utils/pest_utils.py
@@ -507,7 +507,10 @@ def run_from_config(configfile, run_model=True, **kwargs):
     # -- Run model
     print('\t-> Running model with updated parameters')
     if run_model:
-        mm.run_model(**kwargs)
+        success, output_lines = mm.run_model(**kwargs)
+        if not success:
+            print("\n".join(output_lines))
+            raise RuntimeError("Model run failed. See output above.")
     # -- Extract simulated data
     print('\t-> Extracting simulated values')
     prn = marthe_utils.read_prn(os.path.join(mm.mldir,'historiq.prn'))


### PR DESCRIPTION
## Pull Request Description

The previous implementation used a `subprocess.Popen` block in order to follow the live output when running the MARTHE model during forward runs.

However, this approach has several drawbacks:

1. **Windows:** the GUI already displays the live output, making this implementation useless  
2. **Linux:** in most cases, multiple runs are executed in parallel, and there is no active terminal to monitor live outputs.  
3. **MARTHE itself:** the code already writes both `stdout` and `stderr` to files — `bilandeb.txt` and `mart_ver.txt`.  
4. **Performance:** the `subprocess.Popen` block can cause significant slowdowns in certain parallelization configurations.

**Decision:**  
The `Popen` block has been replaced with `subprocess.run`, without capturing `stdout` or `stderr` in the terminal.  
This change simplifies execution behavior and improves performance, especially in parallel workflows.
